### PR TITLE
fix ios menu double click

### DIFF
--- a/src/components/Header/elements.js
+++ b/src/components/Header/elements.js
@@ -33,10 +33,13 @@ const linkStyles = css`
 
     &:hover {
       color: ${props => props.theme.colors.text};
-      &:after {
-        width: 100%;
-        opacity: 1;
-        transition: all 300ms ease-out;
+
+      @media (pointer: fine) {
+        &:after {
+          width: 100%;
+          opacity: 1;
+          transition: all 300ms ease-out;
+        }
       }
     }
 


### PR DESCRIPTION
there's a [weird issue](https://css-tricks.com/annoying-mobile-double-tap-link-issue/) on ios that means if you create an after pseudoelement on hover then you have to tap it twice, this fixes it. 