### PR TITLE
swap from grid to masonry columns

### DIFF
--- a/src/components/Service/work-stage/content.js
+++ b/src/components/Service/work-stage/content.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import { Padding } from 'styled-components-spacing'
 import { Paragraph } from '../../Typography'
-import { Item } from './elements'
+import { Item, WorkStageContentList } from './elements'
 
 const WorkStageContent = ({ sectionTitle, sectionBody, isList }) => (
   <Fragment key={sectionTitle}>
@@ -12,12 +12,14 @@ const WorkStageContent = ({ sectionTitle, sectionBody, isList }) => (
       {sectionBody.split('- ')[0]}
     </Paragraph>
     <Padding top={1.5}>
-      {sectionBody
-        .split('- ')
-        .slice(1)
-        .map(c => (
-          <Item key={c}>{c}</Item>
-        ))}
+      <WorkStageContentList>
+        {sectionBody
+          .split('- ')
+          .slice(1)
+          .map(c => (
+            <Item key={c}>{c}</Item>
+          ))}
+      </WorkStageContentList>
     </Padding>
   </Fragment>
 )

--- a/src/components/Service/work-stage/elements.js
+++ b/src/components/Service/work-stage/elements.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import remcalc from 'remcalc'
 import breakpoint from 'styled-components-breakpoint'
 import StyledLink from '../../styledLink'
+import { Col } from 'react-styled-flexboxgrid'
 import { H2 } from '../../Typography'
 
 export const Item = styled.li`
@@ -45,21 +46,34 @@ export const SwitchLink = styled(StyledLink)`
   }
 `
 
-// there's an odd number, give only last no padding
-// there's an even number, give last 2 no padding
-// if it's mobile / tablet, give only the last no padding
-// index={index} last={arr.length - 1} secondLast={arr.length - 2} evenNumber
-export const WorkStageGridPadding = styled.div`
+export const MasonryContainer = styled.div`
+  ${breakpoint('desktop')`
+    column-count: 2;
+    column-gap: 0;
+    column-fill: auto;
+    height: ${props =>
+    props.length % 2 !== 0 // when there's an odd number of elements we have to manually set the height because css
+      ? remcalc(Math.ceil(props.length / 2) * 500)
+      : 'auto'} 
+    padding-bottom: ${remcalc(72)}
+  `}
+`
+
+export const WorkStageGridElement = styled(Col)`
   padding-bottom: ${props => (props.index === props.last ? 0 : remcalc(72))};
+  break-inside: avoid;
 
   ${breakpoint('desktop')`
-    padding-bottom: ${props => {
-    if (props.index === props.last) {
-      return 0
-    } else if (props.evenNumber && props.index === props.secondLast) {
-      return 0
-    } else {
-      return remcalc(72)
-    }
-  }}`};
+    padding-bottom: ${props =>
+    props.index === props.last ||
+      (!props.evenNumber && props.index === props.halfway) ||
+      (props.evenNumber && props.index + 1 === props.halfway)
+      ? 0
+      : remcalc(72)}}`};
+`
+
+export const WorkStageContentList = styled.div`
+  ${breakpoint('desktop')`
+    width: 60%
+  `}
 `

--- a/src/components/Service/work-stage/stage.js
+++ b/src/components/Service/work-stage/stage.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import { Row, Col, Grid } from 'react-styled-flexboxgrid'
 import { Padding } from 'styled-components-spacing'
 import { H2 } from '../../Typography'
-import { SwitchLink, WorkStageGridPadding } from './elements'
+import { SwitchLink, WorkStageGridElement, MasonryContainer } from './elements'
 import WorkStageContent from './content'
 
 const WorkStage = ({ workStage, handleClick, alternatives }) => {
@@ -42,34 +42,40 @@ const WorkStage = ({ workStage, handleClick, alternatives }) => {
             ))}
         </Col>
         <Tag xs={12} md={6}>
-          {sections.map(
-            ({ sectionTitle, sectionBody, sectionIcon }, index, arr) =>
-              workStage.displayType !== 'List' ? (
-                <Col xs={12} md={6}>
-                  <WorkStageGridPadding
+          {workStage.displayType !== 'List' ? (
+            <MasonryContainer length={sections.length}>
+              {sections.map(
+                ({ sectionTitle, sectionBody, sectionIcon }, index, arr) => (
+                  <WorkStageGridElement
                     index={index}
                     last={arr.length - 1}
-                    secondLast={arr.length - 2}
+                    halfway={Math.floor(arr.length / 2)}
                     evenNumber={arr.length % 2 === 0}
+                    xs={12}
+                    key={index}
                   >
                     <Padding bottom={1.5}>
                       <img src={`https://${sectionIcon}`} />
                     </Padding>
+
                     <WorkStageContent
                       isList
                       sectionTitle={sectionTitle}
                       sectionBody={sectionBody}
                     />
-                  </WorkStageGridPadding>
-                </Col>
-              ) : (
-                <Padding bottom={1}>
-                  <WorkStageContent
-                    sectionTitle={sectionTitle}
-                    sectionBody={sectionBody}
-                  />
-                </Padding>
-              )
+                  </WorkStageGridElement>
+                )
+              )}
+            </MasonryContainer>
+          ) : (
+            sections.map(({ sectionTitle, sectionBody }, index) => (
+              <Padding bottom={1} key={index}>
+                <WorkStageContent
+                  sectionTitle={sectionTitle}
+                  sectionBody={sectionBody}
+                />
+              </Padding>
+            ))
           )}
         </Tag>
       </Row>


### PR DESCRIPTION
I've used columns instead of css grid because reasons, this does mean content has to be reordered in contentful when this is merged. 

fixes https://trello.com/c/HwujLckc/112-transform-deliver-the-layout-of-sub-section-is-wrong-at-the-moment-it-seems-that-sections-across-the-columns-are-aligned-at-the