### PR TITLE
add review / PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description - [Trello ticket](put a link to the trello ticket here)
+
+put a short summary of what you did here
+
+## Review template
+
+The below is for reviewers of this PR to copy/paste into the review body and fulfill.
+
+- Old grid break points: 0-599, 600-1095, 1095+
+- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+
+
+I have opened the preview link and:
+
+- [ ] checked that this PR resolves the spec provided from trello / this description
+- [ ] checked the effected pages at all breakpoints
+- [ ] ensured that this PR does not introduce any obvious bugs


### PR DESCRIPTION
Unfortunately you can currently not make a template for PR reviews, but this creates a template for the PR body, which includes a checklist for the reviewers to fill out. 

By obvious bugs I mean that I don't expect the reviewer to do proper thorough manual QA, but I do expect them to notice any obvious problems, especially the kind that would be obvious for the user.

Would love input / feedback on the content, and it can of course evolve as we decide what is necessary 😃 