### PR TITLE
fix image stretch home page mobile

### DIFF
--- a/src/components/Common/animatedLink.js
+++ b/src/components/Common/animatedLink.js
@@ -28,6 +28,17 @@ export const PosterImage = styled(Flex)`
     width: 475px;
     height: 473px;
   `}
+  > img {
+    align-self: center;
+    justify-self: center;
+    ${breakpoint('tablet')`
+      max-width: 475px;
+      max-height: 475px;
+    `}
+    ${breakpoint('desktop')`
+      max-width: 100%
+    `}
+  }
 `
 
 export const CardHeader = styled.header`

--- a/src/components/Homepage/specialty.js
+++ b/src/components/Homepage/specialty.js
@@ -106,7 +106,7 @@ const Specialty = ({ services }) => (
                   </PosterImage>
                 </section>
               </AnimatedLink>
-              <Padding bottom={5} />
+              <Padding bottom={{ mobile: 2.5, tablet: 5 }} />
             </MasonryElement>
           )
         )


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/YO1n9aE9/197-canon-image-overstretched)

the image for canon was stretched in the speciality section - this fixes it so it's closer to the designs and generally isn't broken on all 3 breakpoints.

## Review template

The below is for reviewers of this PR to copy/paste into the review body and fulfill.

- Old grid break points: 0-599, 600-1095, 1095+
- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+

I have opened the preview link and:

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] checked the effected pages at all breakpoints
- [ ] ensured that this PR does not introduce any obvious bugs
