### PR TITLE
use 'speciality' everywhere, remove instances of 'specialty'

### DIFF
--- a/src/components/Speciality/blog.js
+++ b/src/components/Speciality/blog.js
@@ -8,23 +8,23 @@ import Posts from '../posts'
 import Li from '../listItem'
 import makeBlogPosts from '../../utils/makeBlogPosts'
 
-const BlogPosts = ({ specialty }) => (
+const BlogPosts = ({ speciality }) => (
   <Posts>
     {posts =>
-      makeBlogPosts(posts, specialty.title).length > 0 ? (
+      makeBlogPosts(posts, speciality.title).length > 0 ? (
         <Grid>
           <Padding vertical={{ desktop: 4, smallTablet: 3.5 }}>
             <Row>
               <Col width={[1, 1, 1, 1, 6 / 12]}>
                 <SmallerH2>{`From the blog`}</SmallerH2>
                 <Paragraph>{`${
-                  specialty.title
+                  speciality.title
                 } articles created by members of YLD for the community.`}</Paragraph>
               </Col>
               <Col width={[1, 1, 1, 1, 4 / 12]}>
                 <Padding top={1}>
                   <ul>
-                    {makeBlogPosts(posts, specialty.title)
+                    {makeBlogPosts(posts, speciality.title)
                       .slice(0, 3)
                       .map(({ id, uniqueSlug, title, createdAt }) => (
                         <Li key={`${id}`} fullWidthDivider>

--- a/src/components/Speciality/books.js
+++ b/src/components/Speciality/books.js
@@ -39,8 +39,8 @@ const BooksBox = styled.a`
   `}
 `
 
-const BooksSection = ({ specialty }) =>
-  specialty.externalResources.filter(
+const BooksSection = ({ speciality }) =>
+  speciality.externalResources.filter(
     additionalInfo => additionalInfo.type === `Book`
   ).length ? (
     <Grid>
@@ -48,14 +48,14 @@ const BooksSection = ({ specialty }) =>
         <Row>
           <Padding top={4} />
           <Col width={[1]}>
-            <SmallerH2 center>{`${specialty.title.trim()} books`}</SmallerH2>
+            <SmallerH2 center>{`${speciality.title.trim()} books`}</SmallerH2>
             <Paragraph center>
               NodeJS books created by members of YLD for the community.
             </Paragraph>
           </Col>
         </Row>
         <Row>
-          {specialty.externalResources
+          {speciality.externalResources
             .filter(additionalInfo => additionalInfo.type === `Book`)
             .slice(0, 3)
             .map(externalResource => (
@@ -95,8 +95,8 @@ const BooksSection = ({ specialty }) =>
             <Padding top={4}>
               <Flex justifyCenter alignCenter>
                 <FlexItem>
-                  <StyledLink href={specialty.externalResources[11].link}>
-                    {specialty.externalResources[11].title}
+                  <StyledLink href={speciality.externalResources[11].link}>
+                    {speciality.externalResources[11].title}
                   </StyledLink>
                 </FlexItem>
               </Flex>

--- a/src/components/Speciality/community.js
+++ b/src/components/Speciality/community.js
@@ -25,20 +25,20 @@ const ImgContainerCol = styled(Col)`
   align-items: center;
   justify-content: center;
 `
-const CommunitySection = ({ specialty }) => (
+const CommunitySection = ({ speciality }) => (
   <BlueBackground>
     <Trimmer>
       <TrimmedImage
-        alt={specialty.communityBackground.title}
-        src={specialty.communityBackground.file.url}
+        alt={speciality.communityBackground.title}
+        src={speciality.communityBackground.file.url}
       />
       <Padding top={5} bottom={5}>
         <Row>
           <ImgContainerCol width={[1, 1, 1, 1, 6 / 12]}>
-            {specialty.communityLogo ? (
+            {speciality.communityLogo ? (
               <img
-                alt={specialty.communityLogo.title}
-                src={specialty.communityLogo.file.url}
+                alt={speciality.communityLogo.title}
+                src={speciality.communityLogo.file.url}
                 style={{ maxHeight: '100px' }}
               />
             ) : null}
@@ -46,9 +46,9 @@ const CommunitySection = ({ specialty }) => (
           <Col width={[1, 1, 1, 1, 6 / 12]}>
             <SmallerH2
               reverse
-            >{`${specialty.title.trim()} community`}</SmallerH2>
+            >{`${speciality.title.trim()} community`}</SmallerH2>
             <Paragraph reverse muted>
-              {specialty.communityText.content[0].content[0].value}
+              {speciality.communityText.content[0].content[0].value}
             </Paragraph>
           </Col>
         </Row>

--- a/src/components/Speciality/events.js
+++ b/src/components/Speciality/events.js
@@ -9,8 +9,8 @@ const EventBorder = styled(Col)`
   border: 1px solid rgba(51, 51, 51, 0.15);
 `
 
-const EventSection = ({ specialty }) => {
-  const futureEvents = (specialty.events || []).filter(
+const EventSection = ({ speciality }) => {
+  const futureEvents = (speciality.events || []).filter(
     ({ startTime }) => new Date(startTime) > new Date()
   )
 
@@ -19,7 +19,7 @@ const EventSection = ({ specialty }) => {
       <Padding top={6} bottom={6}>
         <Row>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            <SmallerH2>{`Upcoming ${specialty.title} events`}</SmallerH2>
+            <SmallerH2>{`Upcoming ${speciality.title} events`}</SmallerH2>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
             {futureEvents.map(event => (
@@ -28,8 +28,8 @@ const EventSection = ({ specialty }) => {
                   <Row>
                     <Col>
                       <img
-                        src={`https://${specialty.eventIcon.file.url}`}
-                        alt={specialty.eventIcon.title}
+                        src={`https://${speciality.eventIcon.file.url}`}
+                        alt={speciality.eventIcon.title}
                       />
                     </Col>
                     <Col>

--- a/src/components/Speciality/intro.js
+++ b/src/components/Speciality/intro.js
@@ -22,7 +22,7 @@ const IntroRectangle = ({ introTextTitle, introTextBody }) => (
   </IntroBorder>
 )
 
-const IntroSection = ({ specialty }) => (
+const IntroSection = ({ speciality }) => (
   <BlueBackground>
     <Padding top={2} bottom={5}>
       <Grid>
@@ -30,17 +30,17 @@ const IntroSection = ({ specialty }) => (
           <Col width={[1, 1, 1, 1, 6 / 12]}>
             <Flex full column justifyCenter>
               <H1 style={{ fontSize: '42px' }} reverse>
-                {specialty.title}
+                {speciality.title}
               </H1>
               <Paragraph reverse muted>
-                {specialty.seoText.content[0].content[0].value}
+                {speciality.seoText.content[0].content[0].value}
               </Paragraph>
             </Flex>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
             <img
-              alt={specialty.introGraphic.title}
-              src={specialty.introGraphic.file.url}
+              alt={speciality.introGraphic.title}
+              src={speciality.introGraphic.file.url}
               style={{ maxHeight: '100%' }}
             />
           </Col>
@@ -48,7 +48,7 @@ const IntroSection = ({ specialty }) => (
         <Row>
           <Col width={[1]}>
             <Padding top={2} bottom={2}>
-              <H4 reverse>{specialty.introTitle}</H4>
+              <H4 reverse>{speciality.introTitle}</H4>
             </Padding>
           </Col>
         </Row>
@@ -56,16 +56,16 @@ const IntroSection = ({ specialty }) => (
         <Col width={[1]}>
           <Row>
             <IntroRectangle
-              introTextTitle={specialty.introTextTitle1}
-              introTextBody={specialty.introTextBody1}
+              introTextTitle={speciality.introTextTitle1}
+              introTextBody={speciality.introTextBody1}
             />
             <IntroRectangle
-              introTextTitle={specialty.introTextTitle2}
-              introTextBody={specialty.introTextBody2}
+              introTextTitle={speciality.introTextTitle2}
+              introTextBody={speciality.introTextBody2}
             />
             <IntroRectangle
-              introTextTitle={specialty.introTextTitle3}
-              introTextBody={specialty.introTextBody3}
+              introTextTitle={speciality.introTextTitle3}
+              introTextBody={speciality.introTextBody3}
             />
           </Row>
         </Col>

--- a/src/components/Speciality/projects.js
+++ b/src/components/Speciality/projects.js
@@ -31,7 +31,7 @@ const PosterLinks = ({ project }) => (
   </AnimatedLink>
 )
 
-const CompaniesHelped = ({ specialty, noOther }) => (
+const CompaniesHelped = ({ speciality, noOther }) => (
   <Fragment>
     <Row>
       <Col width={[1, 1, 1, 1, 1 / 2]}>
@@ -40,44 +40,44 @@ const CompaniesHelped = ({ specialty, noOther }) => (
         </Padding>
       </Col>
     </Row>
-    <Companies companies={specialty.clients} />
+    <Companies companies={speciality.clients} />
   </Fragment>
 )
 
-const ProjectsSection = ({ specialty }) =>
-  specialty.relatedProjects ? (
+const ProjectsSection = ({ speciality }) =>
+  speciality.relatedProjects ? (
     <Grid>
       <Padding top={5} bottom={5}>
         <Row>
           <Col width={[0, 0, 0, 0, 1 / 2]}>
             <Padding top={7} bottom={5}>
               <H2 noMargin noBottom>
-                {specialty.title}
+                {speciality.title}
               </H2>
               <H2 noMargin muted noTop>
                 related projects
               </H2>
             </Padding>
-            <PosterLinks project={specialty.relatedProjects[0]} />
+            <PosterLinks project={speciality.relatedProjects[0]} />
           </Col>
           <Col width={[1, 1, 1, 1, 0]}>
-            <H2 noMargin>{specialty.title}</H2>
+            <H2 noMargin>{speciality.title}</H2>
             <H2 noMargin muted>
               related projects
             </H2>
           </Col>
           <Col width={[1, 1, 1, 1, 1 / 2]}>
-            <PosterLinks project={specialty.relatedProjects[1]} />
+            <PosterLinks project={speciality.relatedProjects[1]} />
           </Col>
           <Col width={[1, 1, 1, 1, 1 / 2]} />
         </Row>
-        <CompaniesHelped specialty={specialty} />
+        <CompaniesHelped speciality={speciality} />
       </Padding>
     </Grid>
   ) : (
     <Grid>
       <Padding top={5} bottom={5}>
-        <CompaniesHelped noOther specialty={specialty} />
+        <CompaniesHelped noOther speciality={speciality} />
       </Padding>
     </Grid>
   )

--- a/src/components/Speciality/talks.js
+++ b/src/components/Speciality/talks.js
@@ -39,15 +39,15 @@ const TalkLinkCol = styled(Col)`
     }
   `}
 `
-const TalksSection = ({ specialty }) => {
-  const talks = specialty.externalResources.filter(
+const TalksSection = ({ speciality }) => {
+  const talks = speciality.externalResources.filter(
     ({ type, additionalInfo }) => type === 'Talk' && !additionalInfo
   )
-  const featured = specialty.externalResources.filter(
+  const featured = speciality.externalResources.filter(
     ({ type, additionalInfo }) =>
       type === 'Talk' && additionalInfo === 'Featured'
   )[0]
-  const cta = specialty.externalResources.filter(
+  const cta = speciality.externalResources.filter(
     ({ type, additionalInfo }) => type === 'Talk' && additionalInfo === 'CTA'
   )[0]
   return talks.length ? (
@@ -80,8 +80,8 @@ const TalksSection = ({ specialty }) => {
                 <TalkLinkCol width={[1, 1, 1, 1, 4 / 12]} key={id}>
                   <TalkLink href={link}>
                     <PlayIcon
-                      src={`https://${specialty.videoIcon.file.url}`}
-                      alt={specialty.videoIcon.title}
+                      src={`https://${speciality.videoIcon.file.url}`}
+                      alt={speciality.videoIcon.title}
                     />
                     <Paragraph reverse muted noMargin>
                       {title}

--- a/src/components/Speciality/training.js
+++ b/src/components/Speciality/training.js
@@ -17,38 +17,38 @@ const TrainingStage = ({ title, body, icon }) => (
   </Col>
 )
 
-const TrainingSection = ({ specialty }) => (
+const TrainingSection = ({ speciality }) => (
   <GrayBackground noTop>
     <Padding top={4} bottom={6}>
       <Grid>
         <Row>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            <SmallerH2>{`${specialty.title.trim()} training`}</SmallerH2>
+            <SmallerH2>{`${speciality.title.trim()} training`}</SmallerH2>
             <Paragraph>
-              {specialty.trainingIntroText.content[0].content[0].value}
+              {speciality.trainingIntroText.content[0].content[0].value}
             </Paragraph>
           </Col>
         </Row>
         <Row>
           <TrainingStage
-            title={specialty.trainingTextTitle1}
-            body={specialty.trainingTextBody1}
-            icon={specialty.trainingTextIcon1}
+            title={speciality.trainingTextTitle1}
+            body={speciality.trainingTextBody1}
+            icon={speciality.trainingTextIcon1}
           />
           <TrainingStage
-            title={specialty.trainingTextTitle2}
-            body={specialty.trainingTextBody2}
-            icon={specialty.trainingTextIcon2}
+            title={speciality.trainingTextTitle2}
+            body={speciality.trainingTextBody2}
+            icon={speciality.trainingTextIcon2}
           />
           <TrainingStage
-            title={specialty.trainingTextTitle3}
-            body={specialty.trainingTextBody3}
-            icon={specialty.trainingTextIcon3}
+            title={speciality.trainingTextTitle3}
+            body={speciality.trainingTextBody3}
+            icon={speciality.trainingTextIcon3}
           />
         </Row>
         <Row>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            <StyledLink>{`Request ${specialty.title} training`}</StyledLink>
+            <StyledLink>{`Request ${speciality.title} training`}</StyledLink>
           </Col>
         </Row>
       </Grid>

--- a/src/components/Speciality/tutorials.js
+++ b/src/components/Speciality/tutorials.js
@@ -12,8 +12,8 @@ const TutorialsGrid = styled(Grid)`
   padding-bottom: ${remcalc(18)};
 `
 
-const TutorialsSection = ({ specialty }) =>
-  specialty.externalResources.filter(
+const TutorialsSection = ({ speciality }) =>
+  speciality.externalResources.filter(
     externalResource => externalResource.type === `Tutorial`
   ).length > 0 ? (
     <GrayBackground noTop>
@@ -28,7 +28,7 @@ const TutorialsSection = ({ specialty }) =>
             </Col>
             <Col width={[1, 1, 1, 1, 6 / 12]}>
               <ul>
-                {specialty.externalResources
+                {speciality.externalResources
                   .filter(
                     externalResource => externalResource.type === `Tutorial`
                   )
@@ -49,8 +49,8 @@ const TutorialsSection = ({ specialty }) =>
                   ))}
               </ul>
               <Padding top={3}>
-                <StyledLink href={specialty.externalResources[7].link}>
-                  {specialty.externalResources[7].title}
+                <StyledLink href={speciality.externalResources[7].link}>
+                  {speciality.externalResources[7].title}
                 </StyledLink>
               </Padding>
             </Col>

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -14,44 +14,44 @@ import TutorialsSection from '../components/Speciality/tutorials'
 import BooksSection from '../components/Speciality/books'
 import BlogPostsSection from '../components/Speciality/blog'
 
-const Specialty = ({ data }) => {
-  const specialty = data.allContentfulSpeciality.edges[0].node
+const Speciality = ({ data }) => {
+  const speciality = data.allContentfulSpeciality.edges[0].node
   const site = data.site
   return (
-    <Layout blue logoColour={specialty.logoColour}>
+    <Layout blue logoColour={speciality.logoColour}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
-          specialty.title ? '- ' + specialty.title : ''
-        } ${specialty.seoTitle ? '- ' + specialty.seoTitle : ''} `}
+          speciality.title ? '- ' + speciality.title : ''
+        } ${speciality.seoTitle ? '- ' + speciality.seoTitle : ''} `}
         meta={[
           {
             name: 'description',
-            content: specialty.seoMetaDescription
+            content: speciality.seoMetaDescription
           }
         ]}
       >
         <html lang="en" />
       </Helmet>
-      <IntroSection specialty={specialty} />
-      <ProjectsSection specialty={specialty} />
-      <TrainingSection specialty={specialty} />
-      {specialty.communityText ? (
-        <CommunitySection specialty={specialty} />
+      <IntroSection speciality={speciality} />
+      <ProjectsSection speciality={speciality} />
+      <TrainingSection speciality={speciality} />
+      {speciality.communityText ? (
+        <CommunitySection speciality={speciality} />
       ) : null}
-      <EventSection specialty={specialty} />
-      <TalksSection specialty={specialty} />
-      <BlogPostsSection specialty={specialty} />
-      <TutorialsSection specialty={specialty} />
-      <BooksSection specialty={specialty} />
+      <EventSection speciality={speciality} />
+      <TalksSection speciality={speciality} />
+      <BlogPostsSection speciality={speciality} />
+      <TutorialsSection speciality={speciality} />
+      <BooksSection speciality={speciality} />
       <TalkToUsSection
-        title={specialty.title}
-        contactText={specialty.contactText}
+        title={speciality.title}
+        contactText={speciality.contactText}
       />
     </Layout>
   )
 }
 
-export default Specialty
+export default Speciality
 
 export const pageQuery = graphql`
   query($id: String) {


### PR DESCRIPTION
## Change all instances of 'specialty' in the codebase to 'speciality' - [Trello ticket](https://trello.com/c/ntkPcfkd/219-change-all-instances-of-specialty-in-the-codebase-to-speciality-in-order-to-match-contentful)

Just picked a single spelling - the one we use in Contentful so we don't have to change the content model