### PR TITLE
simplify content model so that 'service' can never be a speciality

### DIFF
--- a/src/pages/case-study/_stackable-rebranding-the-orginal-cloud.js
+++ b/src/pages/case-study/_stackable-rebranding-the-orginal-cloud.js
@@ -376,10 +376,8 @@ export const query = graphql`
             genericText7
           }
           services {
-            ... on ContentfulService {
-              title
-              id
-            }
+            title
+            id
           }
           posterColor
           seoTitle

--- a/src/pages/case-study/canon-giving-stories-a-new-form.js
+++ b/src/pages/case-study/canon-giving-stories-a-new-form.js
@@ -333,10 +333,8 @@ export const query = graphql`
             genericText5
           }
           services {
-            ... on ContentfulService {
-              title
-              id
-            }
+            title
+            id
           }
           posterColor
           seoTitle

--- a/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
+++ b/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
@@ -469,14 +469,8 @@ export const query = graphql`
             genericText9
           }
           services {
-            ... on ContentfulService {
-              title
-              id
-            }
-            ... on ContentfulSpeciality {
-              title
-              id
-            }
+            title
+            id
           }
           posterColor
           seoTitle


### PR DESCRIPTION
## Separate 'services' and 'specialities' into 2 separate fields within Generic Case Study - [Trello ticket](https://trello.com/c/y0v7fLqD/221-change-contentful-model-separate-services-and-specialities-into-2-separate-fields-within-generic-case-study)

- Altered content model in Contentful. We now have 2 fields: `services` & `sepcialities`. Each one only accepts the relevant reference (used to be that the 'services' field could contain either type)
- Edited graphql queries accordingly