### PR TITLE
grab first paragraph from Contentful for Joyent case study (instead of intro sentence)

### DIFF
--- a/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
+++ b/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
@@ -28,7 +28,7 @@ import { makeText } from '../../utils/makeText'
 //     `}
 // `
 
-const IntroSentenceCol = styled(Col)`
+const ColWithoutExtraPadding = styled(Col)`
   margin-left: auto;
   ${breakpoint('smallTablet')`
     padding-left: 0;
@@ -88,16 +88,18 @@ const IndexPage = ({
           <Col width={[1, 1, 1, 1, 1 / 2]}>
             <H2>The challenge</H2>
           </Col>
-          <IntroSentenceCol width={[1, 1, 1, 1, 1 / 2]}>
-            <Paragraph fullWidth>
-              {caseStudy.introSentence.introSentence}
-            </Paragraph>
+          <ColWithoutExtraPadding width={[1, 1, 1, 1, 1 / 2]}>
             {makeText(caseStudy.genericText1.genericText1).map((p, i) => (
               <Paragraph fullWidth key={i}>
                 {p}
               </Paragraph>
             ))}
-          </IntroSentenceCol>
+            {makeText(caseStudy.genericText2.genericText2).map((p, i) => (
+              <Paragraph fullWidth key={i}>
+                {p}
+              </Paragraph>
+            ))}
+          </ColWithoutExtraPadding>
         </Row>
         <Padding bottom={{ smallPhone: 3.5, tablet: 5 }} />
       </Grid>
@@ -110,7 +112,7 @@ const IndexPage = ({
             <Row>
               <Col width={[1, 1, 1, 1, 5 / 12]}>
                 <H2>Single sign-on</H2>
-                {makeText(caseStudy.genericText2.genericText2).map((p, i) => (
+                {makeText(caseStudy.genericText3.genericText3).map((p, i) => (
                   <Paragraph fullWidth key={i}>
                     {p}
                   </Paragraph>
@@ -137,7 +139,7 @@ const IndexPage = ({
               <H2>Navigation</H2>
             </Col>
             <Col width={[1, 1, 1, 1, 1 / 2]}>
-              {makeText(caseStudy.genericText3.genericText3).map((p, i) => (
+              {makeText(caseStudy.genericText4.genericText4).map((p, i) => (
                 <Paragraph fullWidth key={i}>
                   {p}
                 </Paragraph>
@@ -161,7 +163,7 @@ const IndexPage = ({
           <Row>
             <Col width={[1, 1, 1, 1, 6 / 12]}>
               <H2>App deployment</H2>
-              {makeText(caseStudy.genericText4.genericText4).map((p, i) => (
+              {makeText(caseStudy.genericText5.genericText5).map((p, i) => (
                 <Paragraph fullWidth key={i}>
                   {p}
                 </Paragraph>
@@ -240,13 +242,13 @@ const IndexPage = ({
               <Col width={[1, 1, 1, 1, 1 / 2]}>
                 <H2>Metrics visualisation</H2>
               </Col>
-              <IntroSentenceCol width={[1, 1, 1, 1, 1 / 2]}>
+              <ColWithoutExtraPadding width={[1, 1, 1, 1, 1 / 2]}>
                 {makeText(caseStudy.genericText8.genericText8).map((p, i) => (
                   <Paragraph fullWidth key={i}>
                     {p}
                   </Paragraph>
                 ))}
-              </IntroSentenceCol>
+              </ColWithoutExtraPadding>
             </Row>
             <Padding top={{ smallPhone: 3, tablet: 4 }}>
               <Row>
@@ -427,10 +429,6 @@ export const query = graphql`
             file {
               url
             }
-          }
-          introSentence {
-            id
-            introSentence
           }
           genericText1 {
             id


### PR DESCRIPTION
## Change existing Joyent case study - currently pulling intro sentence when it shouldn't - [Trello ticket](https://trello.com/c/wgVGuD0M/223-change-existing-joyent-case-study-currently-pulling-intro-sentence-when-it-shouldnt)

### Background info
![image](https://user-images.githubusercontent.com/15656538/50840871-5de8cb80-135b-11e9-9602-a189687ef0b2.png)

The first paragraph on the Joyent case study ("In the early fall of..."), was entered into Contentful as `introSentence`. So, in the codebase, we are fetching the intro sentence for this page.

But this is incorrect. The `introSentence` field should be used for the "featured case study" component, or the case study cards that are going on the Our work page. Whereas, "In the early fall of..." should be entered into Contentful as `genericText1`

### This PR
So I've changed the content in Contentful, published (but not yet deployed).

This PR contains the necessary change to the codebase, in order to reflect the content alterations