### PR TITLE
fix: fix unnecessary client check on header

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -11,8 +11,6 @@ import menu from '../../images/menu.svg'
 import close from '../../images/menu_close.svg'
 import { MobileMenu, HomeLink, Close, DesktopMenu } from './elements.js'
 
-const isClient = () => typeof window !== 'undefined'
-
 const HiddenText = styled.h1`
   position: absolute;
   top: -9999px;
@@ -25,6 +23,8 @@ class Header extends Component {
   toggleMenu = () => this.setState(state => ({ menuOpen: !state.menuOpen }))
 
   render() {
+    const { location } = this.props
+
     return (
       <Grid>
         <Row>
@@ -33,10 +33,9 @@ class Header extends Component {
               <Padding top={2} bottom={3}>
                 <Flex alignCenter wrap justifyBetween>
                   <Link to="/">
-                    {isClient() &&
-                    !window.location.pathname.includes('engineering') &&
+                    {!location.pathname.includes('engineering') &&
                     !this.props.blue &&
-                    !window.location.pathname.includes('design') ? (
+                    !location.pathname.includes('design') ? (
                       <img
                         role="link"
                         tab-index="0"
@@ -46,8 +45,7 @@ class Header extends Component {
                       />
                     ) : null}
 
-                    {(isClient() &&
-                      window.location.pathname.includes('engineering')) ||
+                    {location.pathname.includes('engineering') ||
                     this.props.blue ? (
                       <Fragment>
                         <HiddenText>engineering</HiddenText>
@@ -58,13 +56,13 @@ class Header extends Component {
                       </Fragment>
                     ) : null}
 
-                    {isClient() && this.props.blue ? (
+                    {this.props.blue ? (
                       <Fragment>
                         <HiddenText>engineering</HiddenText>
                       </Fragment>
                     ) : null}
-                    {isClient() &&
-                    window.location.pathname.includes('design') ? (
+
+                    {location.pathname.includes('design') ? (
                       <Fragment>
                         <HiddenText>Design</HiddenText>
                         <img
@@ -109,6 +107,12 @@ class Header extends Component {
         </Row>
       </Grid>
     )
+  }
+}
+
+Header.defaultProps = {
+  location: {
+    pathname: ''
   }
 }
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -24,7 +24,8 @@ class Layout extends React.Component {
   }
 
   render() {
-    const { children, blue, logoColour } = this.props
+    const { children, blue, logoColour, location } = this.props
+
     return (
       <StaticQuery
         query={graphql`
@@ -50,10 +51,10 @@ class Layout extends React.Component {
               </Helmet>
               {blue && (
                 <BlueBackground>
-                  <Header blue logoColour={logoColour} />
+                  <Header blue logoColour={logoColour} location={location} />
                 </BlueBackground>
               )}
-              {!blue && <Header logoColour={logoColour} />}
+              {!blue && <Header logoColour={logoColour} location={location} />}
               {children}
               <Footer />
               <GlobalStyle />

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -18,8 +18,8 @@ const HomePageLink = styled(LinkStyled)`
   justify-content: center;
 `
 
-const NotFoundPage = ({ data: { site } }) => (
-  <Layout>
+const NotFoundPage = ({ data: { site }, location }) => (
+  <Layout location={location}>
     <Helmet
       title={`${site.siteMetadata.title} - Not Found`}
       meta={[

--- a/src/pages/case-study/_stackable-rebranding-the-orginal-cloud.js
+++ b/src/pages/case-study/_stackable-rebranding-the-orginal-cloud.js
@@ -77,11 +77,12 @@ const Type2 = styled.img`
 `
 
 const IndexPage = ({
-  data: { allContentfulGenericCaseStudy: content, site }
+  data: { allContentfulGenericCaseStudy: content, site },
+  location
 }) => {
   const caseStudy = content.edges[0].node
   return (
-    <Layout>
+    <Layout location={location}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
           content.title ? '- ' + content.title : ''

--- a/src/pages/case-study/canon-giving-stories-a-new-form.js
+++ b/src/pages/case-study/canon-giving-stories-a-new-form.js
@@ -116,11 +116,12 @@ const Video = () => (
 )
 
 const IndexPage = ({
-  data: { allContentfulGenericCaseStudy: content, site, travel }
+  data: { allContentfulGenericCaseStudy: content, site, travel },
+  location
 }) => {
   const caseStudy = content.edges[0].node
   return (
-    <Layout>
+    <Layout location={location}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
           content.title ? '- ' + content.title : ''

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -82,7 +82,7 @@ class ContactUs extends Component {
     const site = this.props.data.site
     const page = this.props.data.allContentfulPage.edges[0].node
     return (
-      <Layout>
+      <Layout location={this.props.location}>
         <GreyBG topMargin>
           <Helmet
             title={`${site.siteMetadata.title}  ${

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -81,8 +81,9 @@ class ContactUs extends Component {
     const { name, email, message, submitting, success } = this.state
     const site = this.props.data.site
     const page = this.props.data.allContentfulPage.edges[0].node
+    const { location } = this.props
     return (
-      <Layout location={this.props.location}>
+      <Layout location={location}>
         <GreyBG topMargin>
           <Helmet
             title={`${site.siteMetadata.title}  ${

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,60 +15,66 @@ import Services from '../components/Homepage/services'
 import GreyBackground from '../components/GreyBG'
 
 const IndexPage = ({
-  data: { contentfulHomepage: content, allContentfulMeetupEvent: events, site }
-}) => (
-  <Layout>
-    <Helmet
-      title={`${site.siteMetadata.title} ${
-        content.seoTitle ? '- ' + content.seoTitle : ''
-      } `}
-      meta={[{ name: 'description', content: content.seoMetaDescription }]}
-    >
-      <html lang="en" />
-    </Helmet>
-    <Grid>
-      <Padding bottom={{ smallPhone: 0, smallTablet: 2, desktop: 2 }}>
-        <CaseStudy
-          caseStudy={content.featuredCaseStudy}
-          subHeading="Featured work"
-        />
-      </Padding>
-      <Padding bottom={{ smallPhone: 0, desktop: 2 }} />
-    </Grid>
-    <GreyBackground topMargin>
-      <Grid>
-        <Padding top={{ smallPhone: 2 }} />
-        <Padding top={{ smallPhone: 4, smallTablet: 5, desktop: 6 }} bottom={3}>
-          <SEOText text={content.seoText.content[0].content} />
-          <Padding bottom={{ smallPhone: 2, smallTablet: 4, desktop: 4 }} />
-          <Companies companies={content.companies} />
-        </Padding>
-      </Grid>
-    </GreyBackground>
-    <Grid>
-      <Services services={content.services} />
-    </Grid>
-    <GreyBackground topMargin>
-      <Grid pt={4}>
-        <Padding bottom={{ smallPhone: 3.5, smallTablet: 3.5 }}>
-          <Events events={events.edges} />
-        </Padding>
-      </Grid>
-    </GreyBackground>
-    <Grid>
-      <Padding
-        top={{ smallPhone: 3, smallTablet: 4 }}
-        bottom={{ smallPhone: 3.5, smallTablet: 3.5 }}
+  data: { contentfulHomepage: content, allContentfulMeetupEvent: events, site },
+  location
+}) => {
+  return (
+    <Layout location={location}>
+      <Helmet
+        title={`${site.siteMetadata.title} ${
+          content.seoTitle ? '- ' + content.seoTitle : ''
+        } `}
+        meta={[{ name: 'description', content: content.seoMetaDescription }]}
       >
-        <Blog />
-      </Padding>
-    </Grid>
-    <GreyBackground>
-      <Jobs />
-      <Padding bottom={{ smallPhone: 1.5, smallTablet: 0 }} />
-    </GreyBackground>
-  </Layout>
-)
+        <html lang="en" />
+      </Helmet>
+      <Grid>
+        <Padding bottom={{ smallPhone: 0, smallTablet: 2, desktop: 2 }}>
+          <CaseStudy
+            caseStudy={content.featuredCaseStudy}
+            subHeading="Featured work"
+          />
+        </Padding>
+        <Padding bottom={{ smallPhone: 0, desktop: 2 }} />
+      </Grid>
+      <GreyBackground topMargin>
+        <Grid>
+          <Padding top={{ smallPhone: 2 }} />
+          <Padding
+            top={{ smallPhone: 4, smallTablet: 5, desktop: 6 }}
+            bottom={3}
+          >
+            <SEOText text={content.seoText.content[0].content} />
+            <Padding bottom={{ smallPhone: 2, smallTablet: 4, desktop: 4 }} />
+            <Companies companies={content.companies} />
+          </Padding>
+        </Grid>
+      </GreyBackground>
+      <Grid>
+        <Services services={content.services} />
+      </Grid>
+      <GreyBackground topMargin>
+        <Grid pt={4}>
+          <Padding bottom={{ smallPhone: 3.5, smallTablet: 3.5 }}>
+            <Events events={events.edges} />
+          </Padding>
+        </Grid>
+      </GreyBackground>
+      <Grid>
+        <Padding
+          top={{ smallPhone: 3, smallTablet: 4 }}
+          bottom={{ smallPhone: 3.5, smallTablet: 3.5 }}
+        >
+          <Blog />
+        </Padding>
+      </Grid>
+      <GreyBackground>
+        <Jobs />
+        <Padding bottom={{ smallPhone: 1.5, smallTablet: 0 }} />
+      </GreyBackground>
+    </Layout>
+  )
+}
 
 export const query = graphql`
   query {

--- a/src/templates/caseStudy.js
+++ b/src/templates/caseStudy.js
@@ -17,12 +17,12 @@ const Stat = styled(H2)`
   padding-bottom: 0 !important; /* sorry */
 `
 
-const CaseStudy = ({ data: { allContentfulCaseStudy, site } }) => {
+const CaseStudy = ({ data: { allContentfulCaseStudy, site }, location }) => {
   const caseStudy = allContentfulCaseStudy.edges[0].node
   const body = generateCaseStudy(caseStudy)
 
   return (
-    <Layout>
+    <Layout location={location}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
           caseStudy.title ? '- ' + caseStudy.title : ''

--- a/src/templates/policy.js
+++ b/src/templates/policy.js
@@ -32,12 +32,12 @@ const Section = styled.section`
 
 const renderParagraphs = content =>
   makeText(content).map(cont => <p key={cont.trim()}>{cont}</p>)
-const Policy = ({ data }) => {
+const Policy = ({ data, location }) => {
   const policy = data.allContentfulPolicy.edges[0].node
   const site = data.site
 
   return (
-    <Layout>
+    <Layout location={location}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
           policy.title ? '- ' + policy.title : ''

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -33,11 +33,11 @@ const WeWorkWithPadding = styled.div`
   `}
 `
 
-const Service = ({ data }) => {
+const Service = ({ data, location }) => {
   const service = data.allContentfulService.edges[0].node
   const site = data.site
   return (
-    <Layout>
+    <Layout location={location}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
           service.title ? '- ' + service.title : ''

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -14,11 +14,11 @@ import TutorialsSection from '../components/Speciality/tutorials'
 import BooksSection from '../components/Speciality/books'
 import BlogPostsSection from '../components/Speciality/blog'
 
-const Speciality = ({ data }) => {
+const Speciality = ({ data, location }) => {
   const speciality = data.allContentfulSpeciality.edges[0].node
   const site = data.site
   return (
-    <Layout blue logoColour={speciality.logoColour}>
+    <Layout blue logoColour={speciality.logoColour} location={location}>
       <Helmet
         title={`${site.siteMetadata.title}  ${
           speciality.title ? '- ' + speciality.title : ''


### PR DESCRIPTION
## Description - [Trello ticket](put a link to the trello ticket here)

Currently we were checking if we were on the client side because we were using the `window.location.pathname` to do some logic. However, Gatsby injects the location as a prop on every page component. This way, we can pass our location to the `Layout` and from then to the `Header` component and use it safely with less checks.

I wish there was a way to also inject the location into the header directly but it doesn't seem like it.

Note: I ran `gatsby build` and served the build — everything looked ok.


Thoughts are welcome :)

## Review template

The below is for reviewers of this PR to copy/paste into the review body and fulfill.

- Old grid break points: 0-599, 600-1095, 1095+
- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+

I have opened the preview link and:

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] checked the effected pages at all breakpoints
- [ ] ensured that this PR does not introduce any obvious bugs
