### PR TITLE
feat: add CompactVideoLink

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   moduleNameMapper: {
     '.+\\.(css|styl|less|sass|scss)$': 'identity-obj-proxy',
     '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      '<rootDir>/.jest/__mocks__/fileMock.js'
+      '<rootDir>/.jest/__mocks__/fileMocks.js'
   },
   testPathIgnorePatterns: [
     '<rootDir>/node_modules',

--- a/src/components/Common/CompactVideoLink.js
+++ b/src/components/Common/CompactVideoLink.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import styled from 'styled-components'
+import breakpoint from 'styled-components-breakpoint'
+import { Col } from '../grid'
+import { Padding, Margin } from 'styled-components-spacing'
+import theme from '../../utils/theme'
+import { Paragraph } from '../Typography'
+import darkIcon from '../../images/button-play-dark.svg'
+import lightIcon from '../../images/button-play-light.svg'
+
+const Wrapper = styled(Col)`
+  ${breakpoint('smallTablet')`
+    &:nth-child(3) {
+        display: none;
+    }
+  `}
+
+  ${breakpoint('tablet')`
+    &:nth-child(3) {
+      display: flex;
+    }
+  `}
+`
+const PlayIcon = styled.img`
+  height: ${theme.spacing[2]};
+  width: ${theme.spacing[2]};
+  max-height: ${theme.spacing[2]};
+  max-width: ${theme.spacing[2]};
+`
+const TruncatedParagraph = styled(Paragraph)`
+  max-height: 3rem;
+  overflow: hidden;
+  color: ${props => props.color};
+  opacity: ${props => props.opacity};
+
+  @supports (-webkit-line-clamp: 2) {
+    max-height: none;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`
+
+const Link = styled.a`
+  display: block;
+`
+const Content = styled.div`
+  display: flex;
+`
+const getColorBasedOnBackground = bg => {
+  switch (bg) {
+    case 'dark':
+      return {
+        opacity: 0.5,
+        useLightIcon: true,
+        color: theme.colors.white
+      }
+    case 'white':
+    case 'grey':
+    default:
+      return {
+        opacity: 1,
+        useLightIcon: false,
+        color: theme.colors.text
+      }
+  }
+}
+
+const CompactVideoLink = ({ children, href, bg = 'white', ...props }) => {
+  const { opacity, useLightIcon, color } = getColorBasedOnBackground(bg)
+
+  return (
+    <Wrapper width={[1, 1, 1, 1, 6 / 12, 4 / 12]}>
+      <Margin vertical={{ smallPhone: 1.5, smallTablet: 0 }}>
+        <Padding vertical={1}>
+          <Link
+            target="_blank"
+            rel="noopener noreferrer"
+            href={href}
+            color={color}
+            opacity={opacity}
+            {...props}
+          >
+            <Content>
+              <Margin right={1.5}>
+                <PlayIcon
+                  src={useLightIcon ? lightIcon : darkIcon}
+                  alt="Play button"
+                />
+              </Margin>
+              <TruncatedParagraph color={color} opacity={opacity} noMargin>
+                {children}
+              </TruncatedParagraph>
+            </Content>
+          </Link>
+        </Padding>
+      </Margin>
+    </Wrapper>
+  )
+}
+
+export default CompactVideoLink

--- a/src/components/Speciality/talks.js
+++ b/src/components/Speciality/talks.js
@@ -2,12 +2,12 @@ import React from 'react'
 import remcalc from 'remcalc'
 import Flex from 'styled-flex-component'
 import { Row, Col, Grid } from '../grid'
-import breakpoint from 'styled-components-breakpoint'
-import { SmallerH2, Paragraph } from '../Typography'
+import { SmallerH2 } from '../Typography'
 import { Padding } from 'styled-components-spacing'
 import StyledLink from '../styledLink'
 import BlueBackground from '../BlueBG'
 import styled from 'styled-components'
+import CompactVideoLink from '../Common/CompactVideoLink'
 
 const Video = styled.iframe`
   width: ${remcalc(854)};
@@ -17,28 +17,7 @@ const Video = styled.iframe`
   box-shadow: 0px 0px 90px rgba(255, 255, 255, 0.2),
     0px 0px 20px rgba(255, 255, 255, 0.07);
 `
-const PlayIcon = styled.img`
-  min-height: ${remcalc(24)};
-  max-width: ${remcalc(24)};
-  margin-right: ${remcalc(10)};
-`
 
-const TalkLink = styled.a`
-  display: flex;
-  align-items: start;
-`
-
-const TalkLinkCol = styled(Col)`
-  :not(:first-of-type) {
-    margin-top: 10px;
-  }
-
-  ${breakpoint('tablet')`
-    :not(:first-of-type) {
-      margin-top: 0px;
-    }
-  `}
-`
 const TalksSection = ({ speciality, videoIcon }) => {
   const isTalk = type => type === 'Talk'
   const talks = speciality.externalResources.filter(
@@ -78,18 +57,10 @@ const TalksSection = ({ speciality, videoIcon }) => {
           )}
           <Padding top={4} bottom={4}>
             <Row>
-              {talks.map(({ title, link, additionalInfo, id }) => (
-                <TalkLinkCol width={[1, 1, 1, 1, 4 / 12]} key={id}>
-                  <TalkLink href={link}>
-                    <PlayIcon
-                      src={`https://${videoIcon.file.url}`}
-                      alt={videoIcon.title}
-                    />
-                    <Paragraph reverse muted noMargin>
-                      {title}
-                    </Paragraph>
-                  </TalkLink>
-                </TalkLinkCol>
+              {talks.map(({ title, link, id }) => (
+                <CompactVideoLink href={link} key={id} bg="dark">
+                  {title}
+                </CompactVideoLink>
               ))}
             </Row>
           </Padding>

--- a/src/images/button-play-dark.svg
+++ b/src/images/button-play-dark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36">
+    <g fill="none" fill-rule="evenodd">
+        <circle cx="18" cy="18" r="18" fill="#333"/>
+        <path fill="#FAFAFA" d="M14 11v15l11-7.5z"/>
+    </g>
+</svg>

--- a/src/images/button-play-light.svg
+++ b/src/images/button-play-light.svg
@@ -1,16 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.4 (67378) - http://www.bohemiancoding.com/sketch -->
-    <title>button_play_default</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Tech-SEO" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Tech-SEO-/-Node-/-Desktop" transform="translate(-141.000000, -5568.000000)">
-            <g id="video" transform="translate(141.000000, 5556.000000)">
-                <g id="button_play_default" transform="translate(0.000000, 12.000000)">
-                    <circle id="Oval-2" fill="#FFFFFF" cx="12" cy="12" r="12"></circle>
-                    <polygon id="Page-1" fill="#090329" points="10 7 10 17 17 11.9999646"></polygon>
-                </g>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><circle fill="#FFF" cx="12" cy="12" r="12"/><path fill="#090329" d="M10 7v10l7-5z"/></g></svg>

--- a/src/images/button-play-light.svg
+++ b/src/images/button-play-light.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.4 (67378) - http://www.bohemiancoding.com/sketch -->
+    <title>button_play_default</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Tech-SEO" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Tech-SEO-/-Node-/-Desktop" transform="translate(-141.000000, -5568.000000)">
+            <g id="video" transform="translate(141.000000, 5556.000000)">
+                <g id="button_play_default" transform="translate(0.000000, 12.000000)">
+                    <circle id="Oval-2" fill="#FFFFFF" cx="12" cy="12" r="12"></circle>
+                    <polygon id="Page-1" fill="#090329" points="10 7 10 17 17 11.9999646"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -1,8 +1,350 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Compact Video Link Dark bg 1`] = `
+<section
+  className="sc-jzJRlG lfQJfN"
+>
+  <div
+    className="sc-bwzfXH ciboha"
+  >
+    <div
+      className="sc-gZMcBi czhXCo sc-bwzfXH imfoSK"
+      width={
+        Array [
+          1,
+          1,
+          1,
+          1,
+          0.5,
+          0.3333333333333333,
+        ]
+      }
+    >
+      <div
+        className="sc-htpNat hOSvSf"
+      >
+        <div
+          className="sc-bxivhb icukFi"
+        >
+          <a
+            className="sc-jTzLTM ZdqHv"
+            color="#fff"
+            href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+            opacity={0.5}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <div
+              className="sc-fjdhpX fdxDzp"
+            >
+              <div
+                className="sc-htpNat hSZREN"
+              >
+                <img
+                  alt="Play button"
+                  className="sc-gqjmRU heUaDl"
+                  src="test-file-stub"
+                />
+              </div>
+              <p
+                className="sc-VigVT jEpWYT"
+                color="#fff"
+                opacity={0.5}
+              >
+                Manipulating the Web Audio API with JSX and Custom Renderers - James Wright
+              </p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Storyshots Compact Video Link Grey bg 1`] = `
+<section
+  className="sc-cSHVUG FwFfO"
+>
+  <div
+    className="sc-bwzfXH ciboha"
+  >
+    <div
+      className="sc-gZMcBi czhXCo sc-bwzfXH imfoSK"
+      width={
+        Array [
+          1,
+          1,
+          1,
+          1,
+          0.5,
+          0.3333333333333333,
+        ]
+      }
+    >
+      <div
+        className="sc-htpNat hOSvSf"
+      >
+        <div
+          className="sc-bxivhb icukFi"
+        >
+          <a
+            className="sc-jTzLTM ZdqHv"
+            color="#333333"
+            href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+            opacity={1}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <div
+              className="sc-fjdhpX fdxDzp"
+            >
+              <div
+                className="sc-htpNat hSZREN"
+              >
+                <img
+                  alt="Play button"
+                  className="sc-gqjmRU heUaDl"
+                  src="test-file-stub"
+                />
+              </div>
+              <p
+                className="sc-VigVT ihPljm"
+                color="#333333"
+                opacity={1}
+              >
+                Manipulating the Web Audio API with JSX and Custom Renderers - James Wright
+              </p>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Storyshots Compact Video Link Multiple Components component 1`] = `
+<div
+  className="sc-bwzfXH ciboha"
+>
+  <div
+    className="sc-gZMcBi czhXCo sc-bwzfXH imfoSK"
+    width={
+      Array [
+        1,
+        1,
+        1,
+        1,
+        0.5,
+        0.3333333333333333,
+      ]
+    }
+  >
+    <div
+      className="sc-htpNat hOSvSf"
+    >
+      <div
+        className="sc-bxivhb icukFi"
+      >
+        <a
+          className="sc-jTzLTM ZdqHv"
+          color="#333333"
+          href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+          opacity={1}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <div
+            className="sc-fjdhpX fdxDzp"
+          >
+            <div
+              className="sc-htpNat hSZREN"
+            >
+              <img
+                alt="Play button"
+                className="sc-gqjmRU heUaDl"
+                src="test-file-stub"
+              />
+            </div>
+            <p
+              className="sc-VigVT ihPljm"
+              color="#333333"
+              opacity={1}
+            >
+              Manipulating the Web Audio API with JSX and Custom Renderers - James Wright
+            </p>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
+    className="sc-gZMcBi czhXCo sc-bwzfXH imfoSK"
+    width={
+      Array [
+        1,
+        1,
+        1,
+        1,
+        0.5,
+        0.3333333333333333,
+      ]
+    }
+  >
+    <div
+      className="sc-htpNat hOSvSf"
+    >
+      <div
+        className="sc-bxivhb icukFi"
+      >
+        <a
+          className="sc-jTzLTM ZdqHv"
+          color="#333333"
+          href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+          opacity={1}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <div
+            className="sc-fjdhpX fdxDzp"
+          >
+            <div
+              className="sc-htpNat hSZREN"
+            >
+              <img
+                alt="Play button"
+                className="sc-gqjmRU heUaDl"
+                src="test-file-stub"
+              />
+            </div>
+            <p
+              className="sc-VigVT ihPljm"
+              color="#333333"
+              opacity={1}
+            >
+              Manipulating the Web Audio API with JSX and Custom Renderers - James Wright
+            </p>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+  <div
+    className="sc-gZMcBi czhXCo sc-bwzfXH imfoSK"
+    width={
+      Array [
+        1,
+        1,
+        1,
+        1,
+        0.5,
+        0.3333333333333333,
+      ]
+    }
+  >
+    <div
+      className="sc-htpNat hOSvSf"
+    >
+      <div
+        className="sc-bxivhb icukFi"
+      >
+        <a
+          className="sc-jTzLTM ZdqHv"
+          color="#333333"
+          href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+          opacity={1}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <div
+            className="sc-fjdhpX fdxDzp"
+          >
+            <div
+              className="sc-htpNat hSZREN"
+            >
+              <img
+                alt="Play button"
+                className="sc-gqjmRU heUaDl"
+                src="test-file-stub"
+              />
+            </div>
+            <p
+              className="sc-VigVT ihPljm"
+              color="#333333"
+              opacity={1}
+            >
+              Manipulating the Web Audio API with JSX and Custom Renderers - James Wright
+            </p>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Compact Video Link Single component 1`] = `
+<div
+  className="sc-bwzfXH ciboha"
+>
+  <div
+    className="sc-gZMcBi czhXCo sc-bwzfXH imfoSK"
+    width={
+      Array [
+        1,
+        1,
+        1,
+        1,
+        0.5,
+        0.3333333333333333,
+      ]
+    }
+  >
+    <div
+      className="sc-htpNat hOSvSf"
+    >
+      <div
+        className="sc-bxivhb icukFi"
+      >
+        <a
+          className="sc-jTzLTM ZdqHv"
+          color="#333333"
+          href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+          opacity={1}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <div
+            className="sc-fjdhpX fdxDzp"
+          >
+            <div
+              className="sc-htpNat hSZREN"
+            >
+              <img
+                alt="Play button"
+                className="sc-gqjmRU heUaDl"
+                src="test-file-stub"
+              />
+            </div>
+            <p
+              className="sc-VigVT ihPljm"
+              color="#333333"
+              opacity={1}
+            >
+              Manipulating the Web Audio API with JSX and Custom Renderers - James Wright
+            </p>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Form Button 1`] = `
 <button
-  className="sc-gZMcBi gTQthr"
+  className="sc-kpOJdX hNdAcX"
 >
   Click Me
 </button>
@@ -10,10 +352,10 @@ exports[`Storyshots Form Button 1`] = `
 
 exports[`Storyshots Form Checkbox 1`] = `
 <section
-  className="sc-VigVT iARuFr"
+  className="sc-ckVGcZ cLXKCv"
 >
   <input
-    className="sc-gzVnrw geKrCW"
+    className="sc-kAzzGY fYcsoX"
     id="checkbox"
     name="checkbox"
     type="checkbox"
@@ -28,10 +370,10 @@ exports[`Storyshots Form Checkbox 1`] = `
 
 exports[`Storyshots Form Field 1`] = `
 <section
-  className="sc-gqjmRU gIbBcD"
+  className="sc-dxgOiQ gsKjl"
 >
   <input
-    className="sc-htoDjs jgVuvd"
+    className="sc-chPdSV evKaBU"
     placeholder="test"
     type="text"
   />
@@ -40,10 +382,10 @@ exports[`Storyshots Form Field 1`] = `
 
 exports[`Storyshots Form Fieldset 1`] = `
 <section
-  className="sc-VigVT iARuFr"
+  className="sc-ckVGcZ cLXKCv"
 >
   <input
-    className="sc-htoDjs jgVuvd"
+    className="sc-chPdSV evKaBU"
     placeholder="test"
     type="text"
   />
@@ -52,7 +394,7 @@ exports[`Storyshots Form Fieldset 1`] = `
 
 exports[`Storyshots Form Input 1`] = `
 <input
-  className="sc-htoDjs jgVuvd"
+  className="sc-chPdSV evKaBU"
   placeholder="test"
   type="text"
 />
@@ -60,7 +402,7 @@ exports[`Storyshots Form Input 1`] = `
 
 exports[`Storyshots Form Label 1`] = `
 <label
-  className="sc-dnqmqq cntxcn"
+  className="sc-kgoBCf bbkuDQ"
 >
   Label
 </label>
@@ -68,14 +410,14 @@ exports[`Storyshots Form Label 1`] = `
 
 exports[`Storyshots Form Textarea 1`] = `
 <textarea
-  className="sc-iwsKbI dpOqPg"
+  className="sc-kGXeez jmKxiL"
   placeholder="test"
 />
 `;
 
 exports[`Storyshots Typography Large Body 1`] = `
 <h3
-  className="sc-htpNat deHCEJ"
+  className="sc-bZQynM bdjeOF"
 >
   Large Body
 </h3>
@@ -83,7 +425,7 @@ exports[`Storyshots Typography Large Body 1`] = `
 
 exports[`Storyshots Typography Large title 1`] = `
 <h1
-  className="sc-bdVaJa bcdDQm"
+  className="sc-ifAKCX kRxalI"
 >
   Large title
 </h1>
@@ -91,7 +433,7 @@ exports[`Storyshots Typography Large title 1`] = `
 
 exports[`Storyshots Typography Small Title 1 1`] = `
 <h4
-  className="sc-bxivhb gwyPxj"
+  className="sc-gzVnrw iltYUC"
 >
   Small Title
 </h4>
@@ -99,7 +441,7 @@ exports[`Storyshots Typography Small Title 1 1`] = `
 
 exports[`Storyshots Typography Small Title 2 1`] = `
 <h5
-  className="sc-ifAKCX cSrcVm"
+  className="sc-htoDjs jdpgcj"
 >
   Small Title
 </h5>
@@ -107,7 +449,7 @@ exports[`Storyshots Typography Small Title 2 1`] = `
 
 exports[`Storyshots Typography Small Title 3 1`] = `
 <h6
-  className="sc-EHOje kYZbFa"
+  className="sc-dnqmqq fxTddO"
 >
   Small Title
 </h6>

--- a/stories/compactVideoLink.stories.js
+++ b/stories/compactVideoLink.stories.js
@@ -1,0 +1,77 @@
+import React, { Fragment } from 'react'
+
+import { storiesOf, addDecorator } from '@storybook/react'
+import { ThemeProvider } from 'styled-components'
+import theme from '../src/utils/theme'
+import GlobalStyle from '../src/utils/globalStyle'
+import CompactVideoLink from '../src/components/Common/CompactVideoLink'
+import { Row } from '../src/components/grid'
+import BlueBG from '../src/components/BlueBG'
+import GreyBG from '../src/components/GreyBG'
+
+const Theme = storyFn => (
+  <ThemeProvider theme={theme}>
+    <Fragment>
+      {storyFn()}
+      <GlobalStyle />
+    </Fragment>
+  </ThemeProvider>
+)
+
+addDecorator(Theme)
+const text =
+  'Manipulating the Web Audio API with JSX and Custom Renderers - James Wright'
+
+storiesOf('Compact Video Link', module)
+  .add('Single component', () => {
+    return (
+      <Row>
+        <CompactVideoLink href="https://www.youtube.com/watch?v=IeuuBKBb4Wg">
+          {text}
+        </CompactVideoLink>
+      </Row>
+    )
+  })
+  .add('Multiple Components component', () => {
+    return (
+      <Row>
+        <CompactVideoLink href="https://www.youtube.com/watch?v=IeuuBKBb4Wg">
+          {text}
+        </CompactVideoLink>
+        <CompactVideoLink href="https://www.youtube.com/watch?v=IeuuBKBb4Wg">
+          {text}
+        </CompactVideoLink>
+        <CompactVideoLink href="https://www.youtube.com/watch?v=IeuuBKBb4Wg">
+          {text}
+        </CompactVideoLink>
+      </Row>
+    )
+  })
+  .add('Dark bg', () => {
+    return (
+      <BlueBG>
+        <Row>
+          <CompactVideoLink
+            href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+            bg="dark"
+          >
+            {text}
+          </CompactVideoLink>
+        </Row>
+      </BlueBG>
+    )
+  })
+  .add('Grey bg', () => {
+    return (
+      <GreyBG>
+        <Row>
+          <CompactVideoLink
+            href="https://www.youtube.com/watch?v=IeuuBKBb4Wg"
+            bg="grey"
+          >
+            {text}
+          </CompactVideoLink>
+        </Row>
+      </GreyBG>
+    )
+  })


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/QKvyjeKI)

This PR aims to implement a reusable component called `CompactVideoLink` as documented here: https://app.zeplin.io/project/5b4e666f0d4230a16dffd93a/screen/5c3e05702c9f7852505e518f.

This component will be a dependency of a `StandaloneVideoLink` which will be used on the 'Join Us' page.

I created a storybook story for testing/checking the component in an isolated way.

This PR also fixes the following visual issue on the Talks component, it seems the different video links are not vertically aligned with each other.
![image](https://user-images.githubusercontent.com/3236388/51465850-adb69200-1d60-11e9-92e8-85d63ca1b9b8.png)

(at least I think it's a bug @SaraVieira @jsms90 please shout if I'm wrong)

**Please note**: this MR adds 2 svgs for the play button (dark/light). I'm not comfortable with this, since the correct way to do this would be to have a single SVG for the icon, and change the `fill`s accordingly. However, I don't think we had the need to load `svg` files until now (every svg was being added as a `src` of an `img` tag). I think it's best to study the best svg loader solution, but that should be done on separate MR, in my opinion.


## Review template

The below is for reviewers of this PR to copy/paste into the review body and fulfill.

- Old grid break points: 0-599, 600-1095, 1095+
- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+

I have opened the preview link and:

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] checked the effected pages at all breakpoints
- [ ] ensured that this PR does not introduce any obvious bugs
