### PR TITLE
fix: adding defensive code for missing companies collection on homepage

### DIFF
--- a/src/components/Homepage/companies.js
+++ b/src/components/Homepage/companies.js
@@ -8,19 +8,20 @@ const Column = styled(Col)`
   align-items: center;
 `
 
-const Companies = ({ companies }) => (
-  <Grid>
-    <Row>
-      {companies.map(company => (
-        <Column
-          width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 4, 1 / 4]}
-          key={company.id}
-        >
-          <img src={company.file.url} alt={company.title} />
-        </Column>
-      ))}
-    </Row>
-  </Grid>
-)
+const Companies = ({ companies = [] }) =>
+  companies ? (
+    <Grid>
+      <Row>
+        {companies.map(company => (
+          <Column
+            width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 4, 1 / 4]}
+            key={company.id}
+          >
+            <img src={company.file.url} alt={company.title} />
+          </Column>
+        ))}
+      </Row>
+    </Grid>
+  ) : null
 
 export default Companies


### PR DESCRIPTION
## Description - [Trello ticket](put a link to the trello ticket here)

Our build is breaking if there are no `companies` set up for the homepage, on the contentful. 
This code checks before trying to map through the collection..

## Review template

The below is for reviewers of this PR to copy/paste into the review body and fulfill.

- Old grid break points: 0-599, 600-1095, 1095+
- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+

I have opened the preview link and:

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] checked the effected pages at all breakpoints
- [ ] ensured that this PR does not introduce any obvious bugs
