### PR TITLE
add browser support section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ We have some docs to make it easier to get you started:
 
 - [Netlify](https://netlify.com/)
 
+## Browser support
+Browsers people are using to access our website, based on google analytics:
+- 70% chrome
+- 23% safari
+- 3.5% firefox
+- 0.15% IE
+
+We current support:
+- Chrome
+- Firefox
+- Safari
+- Edge
+
+We're working towrads supporting IE11 & introducing graceful fallbacks for earlier versions (for where this sits in our prioritise, see trello).
+
 ## License
 
 [MPL-2](/LICENSE)


### PR DESCRIPTION
## document which browsers we currently support - [Trello ticket](https://trello.com/c/gWJHdGWw/217-browser-support-document-what-we-currently-support-check-ie)

This documentation is based on the conversations that have happened on the attached trello ticket

@SaraVieira's has investigated our current IE situation. You can see a few issues on the screenshots below.

@carvil If we intend to start supporting IE, we may need to do a thorough audit of all the pages, raise tickets & add IE work to the roadmap so that it can be prioritised. What do you think?

# IE11
![win10_ie_11 0](https://user-images.githubusercontent.com/15656538/51752098-83d9d400-20ae-11e9-835c-bd3290c2fdc0.png)

# IE10
![win8_ie_10 0](https://user-images.githubusercontent.com/15656538/51752289-0f536500-20af-11e9-9a41-182ca792cc62.png)
