### PR TITLE
fix: fix close menu icon issue on firefox

### DIFF
--- a/src/components/Header/elements.js
+++ b/src/components/Header/elements.js
@@ -107,6 +107,8 @@ export const Close = styled.button`
   font-size: ${remcalc(40)};
   height: ${remcalc(32)};
   display: flex;
+  flex-direction: column;
+  justify-content: center;
 
   &:focus {
     background: transparent;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -5,7 +5,7 @@ import Flex from 'styled-flex-component'
 import { Padding } from 'styled-components-spacing'
 import Logo from './Logo'
 import menu from '../../images/menu.svg'
-import close from '../../images/menu_close.svg'
+import close from '../../images/close.svg'
 import { MobileMenu, HomeLink, Close, DesktopMenu } from './elements.js'
 
 class Header extends Component {

--- a/src/images/close.svg
+++ b/src/images/close.svg
@@ -1,1 +1,1 @@
-<svg width="18" height="20" xmlns="http://www.w3.org/2000/svg"><path d="M9.092 8.877l7.538-7.782L18 2.51l-7.538 7.783 7.346 7.583-1.37 1.415-7.346-7.584-7.53 7.774-1.37-1.414 7.53-7.774L0 2.319 1.37.905l7.722 7.972z" fill="#FFF" fill-rule="evenodd"/></svg>
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><g fill="#FFF" fill-rule="evenodd"><path d="M2.222.808l16.97 16.97-1.414 1.414L.808 2.222z"/><path d="M1 17.97L17.97 1l1.415 1.414-16.97 16.97z"/></g></svg>

--- a/src/images/menu_close.svg
+++ b/src/images/menu_close.svg
@@ -1,1 +1,0 @@
-<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg"><g fill="#FFF" fill-rule="evenodd"><path d="M2.222.808l16.97 16.97-1.414 1.414L.808 2.222z"/><path d="M1 17.97L17.97 1l1.415 1.414-16.97 16.97z"/></g></svg>


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/85gx409Q)

Fixing issue on close menu button on firefox.
Also, reused the close svg, since it was the same there's no need to have 2 files.


## Review template

The below is for reviewers of this PR to copy/paste into the review body and fulfill.

- Old grid break points: 0-599, 600-1095, 1095+
- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+

I have opened the preview link and:

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] checked the effected pages at all breakpoints
- [ ] ensured that this PR does not introduce any obvious bugs
