### PR TITLE
fix: fix red border on ff text area

### DIFF
--- a/src/components/forms.js
+++ b/src/components/forms.js
@@ -1,5 +1,6 @@
 import remcalc from 'remcalc'
 import styled from 'styled-components'
+import is from 'styled-is'
 
 export const Checkbox = styled.input`
   appearance: none;
@@ -33,6 +34,10 @@ export const Input = styled.input`
   font-size: ${remcalc(18)};
   background: ${props => props.theme.colors.greyBg};
   box-sizing: border-box;
+
+  ${is('noBoxShadow')`
+    box-shadow:none;
+  `};
 `
 
 export const Label = styled('label')`

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -40,7 +40,8 @@ class ContactUs extends Component {
     name: '',
     email: '',
     message: '',
-    submitting: false
+    submitting: false,
+    triedSubmitting: false
   }
 
   handleChangeCheckbox = e => {
@@ -74,6 +75,10 @@ class ContactUs extends Component {
       this.setState({ success: true, submitting: false })
       window.scrollTo(0, 0)
     })
+  }
+
+  handleButtonClick = () => {
+    this.setState({ triedSubmitting: true })
   }
 
   render() {
@@ -146,6 +151,7 @@ class ContactUs extends Component {
                         <Label htmlFor="message">Tell us a bit more</Label>
                         <Input
                           as="textarea"
+                          noBoxShadow={!this.state.triedSubmitting}
                           rows="4"
                           value={message}
                           onChange={this.handleChange}
@@ -189,7 +195,11 @@ class ContactUs extends Component {
                             </label>
                           </section>
                         </Field>
-                        <Button type="submit" disabled={submitting}>
+                        <Button
+                          onClick={this.handleButtonClick}
+                          type="submit"
+                          disabled={submitting}
+                        >
                           {submitting ? 'Submitting' : 'Submit'}
                         </Button>
                       </form>


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/NXhg9dQe)

Fixin error box shadow on firefox's textarea even when the form is pristine.

## Review template

The below is for reviewers of this PR to copy/paste into the review body and fulfill.

- Old grid break points: 0-599, 600-1095, 1095+
- New grid break points: 0-470, 471-552, 553-700, 701-899, 900-1196, 1197+

I have opened the preview link and:

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] checked the effected pages at all breakpoints
- [ ] ensured that this PR does not introduce any obvious bugs
