### PR TITLE
remove 'Talk to us' bug

### DIFF
--- a/src/components/Common/talkToUs.js
+++ b/src/components/Common/talkToUs.js
@@ -14,7 +14,7 @@ const TalkToUsSection = ({ title, contactText }) => (
       >
         <Row>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            <SectionTitle noTop>{`Talk to us about ${title}`}</SectionTitle>
+            <SectionTitle>{title}</SectionTitle>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
             <Padding top={1}>


### PR DESCRIPTION
## Hard-coded 'talk to us' string accidentally reintroduced - [Trello ticket](https://trello.com/c/gsG9KzRe/351-getintouch-component-has-talk-to-us-string-hard-coded-into-it)

When merging the Training page into the typography PR, I accidentally reintroduced the hard coded 'Talk to us' string - https://github.com/yldio/yld.io/pull/95/files#diff-32933ad3090bd956f8bb869dd0087893R17

So this has introduced the following bug to the live website:
![image](https://user-images.githubusercontent.com/15656538/51855679-b9d4bd80-2325-11e9-9f1f-ea1c8213cff0.png)

This PR removes the hard-coded 'Talk to us' again