### PR TITLE
Add/update design specialities

### DIFF
--- a/src/components/Common/CaseStudyCards/CaseStudyHero.js
+++ b/src/components/Common/CaseStudyCards/CaseStudyHero.js
@@ -22,10 +22,8 @@ const SubSection = ({ heading, items }) => (
 
 const SpecialitiesAndServices = ({ specialities, services }) => (
   <Padding top={{ smallPhone: 0, tablet: 0.5 }}>
-    {specialities ? (
-      <SubSection heading="Specialities used" items={specialities} />
-    ) : null}
     <SubSection heading="Services provided" items={services} />
+    <SubSection heading="Specialities involved" items={specialities} />
   </Padding>
 )
 

--- a/src/components/Common/CaseStudyCards/CaseStudyHero.js
+++ b/src/components/Common/CaseStudyCards/CaseStudyHero.js
@@ -23,7 +23,7 @@ const SubSection = ({ heading, items }) => (
 const SpecialitiesAndServices = ({ specialities, services }) => (
   <Padding top={{ smallPhone: 0, tablet: 0.5 }}>
     {specialities ? (
-      <SubSection heading="Technology used" items={specialities} />
+      <SubSection heading="Specialities used" items={specialities} />
     ) : null}
     <SubSection heading="Services provided" items={services} />
   </Padding>

--- a/src/components/Common/CaseStudyCards/CaseStudyHero.js
+++ b/src/components/Common/CaseStudyCards/CaseStudyHero.js
@@ -13,7 +13,7 @@ const FlexCol = styled(Col)`
 
 const SubSection = ({ heading, items }) => (
   <Padding bottom={0.5}>
-    <Subtitle>{heading}</Subtitle>
+    <Subtitle noPaddingBottom>{heading}</Subtitle>
     <Flex alignCenter wrap>
       <SeoLinks noPadding items={items} />
     </Flex>

--- a/src/pages/case-study/canon-giving-stories-a-new-form.js
+++ b/src/pages/case-study/canon-giving-stories-a-new-form.js
@@ -294,6 +294,10 @@ export const query = graphql`
         id
         genericText5
       }
+      specialities {
+        title
+        id
+      }
       services {
         title
         id

--- a/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
+++ b/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
@@ -465,6 +465,10 @@ export const query = graphql`
         id
         genericText9
       }
+      specialities {
+        title
+        id
+      }
       services {
         title
         id

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -23,6 +23,17 @@ const WeWorkWithPadding = styled.div`
 `
 
 const Service = ({ data: { contentfulService: service }, location }) => {
+  const {
+    specialityAreaTitle1,
+    specialityAreaItems1,
+    specialityAreaTitle2,
+    specialityAreaItems2,
+    specialityAreaTitle3,
+    specialityAreaItems3,
+    specialityAreaTitle4,
+    specialityAreaItems4
+  } = service
+
   return (
     <Layout location={location}>
       <Head page={service} />
@@ -64,29 +75,33 @@ const Service = ({ data: { contentfulService: service }, location }) => {
             <Row>
               <Col width={[1, 1, 1, 1, 1 / 2, 3 / 12]}>
                 <WeWorkWithPadding index={1}>
-                  <Subtitle>{service.specialityAreaTitle1}</Subtitle>
-                  <SeoLinks items={service.specialityAreaItems1} />
+                  {specialityAreaTitle1 ? (
+                    <Subtitle>{specialityAreaTitle1}</Subtitle>
+                  ) : null}
+                  <SeoLinks items={specialityAreaItems1} />
                 </WeWorkWithPadding>
               </Col>
               <Col width={[1, 1, 1, 1, 1 / 2, 3 / 12]}>
-                <WeWorkWithPadding index={2}>
-                  <Subtitle>{service.specialityAreaTitle2}</Subtitle>
-                  <SeoLinks items={service.specialityAreaItems2} />
-                </WeWorkWithPadding>
-              </Col>
-              <Col width={[1, 1, 1, 1, 1 / 2, 3 / 12]}>
-                {service.specialityAreaTitle3 && (
-                  <WeWorkWithPadding index={3}>
-                    <Subtitle>{service.specialityAreaTitle3}</Subtitle>
-                    <SeoLinks items={service.specialityAreaItems3} />
+                {specialityAreaItems2 && (
+                  <WeWorkWithPadding index={2}>
+                    <Subtitle>{specialityAreaTitle2}</Subtitle>
+                    <SeoLinks items={specialityAreaItems2} />
                   </WeWorkWithPadding>
                 )}
               </Col>
               <Col width={[1, 1, 1, 1, 1 / 2, 3 / 12]}>
-                {service.specialityAreaTitle4 && (
+                {specialityAreaItems3 && (
+                  <WeWorkWithPadding index={3}>
+                    <Subtitle>{specialityAreaTitle3}</Subtitle>
+                    <SeoLinks items={specialityAreaItems3} />
+                  </WeWorkWithPadding>
+                )}
+              </Col>
+              <Col width={[1, 1, 1, 1, 1 / 2, 3 / 12]}>
+                {specialityAreaItems4 && (
                   <WeWorkWithPadding index={4}>
-                    <Subtitle>{service.specialityAreaTitle4}</Subtitle>
-                    <SeoLinks items={service.specialityAreaItems4} />
+                    <Subtitle>{specialityAreaTitle4}</Subtitle>
+                    <SeoLinks items={specialityAreaItems4} />
                   </WeWorkWithPadding>
                 )}
               </Col>


### PR DESCRIPTION
## Update design specialities & change 'technology used' to 'specialities involved' on CaseStudyHero - [Trello ticket](https://trello.com/c/Z9PobmKF/250-2-update-specialities-applied-aka-casestudyhero-aka-technologies-used)

- get specialities when querying Contentful for all design case studies (non-templated)
- show these new design specialities on CaseStudyHero
  - change subtitle from "technology used" to "specialities involved", as this subtitle now covers engineering specialities + design specialities
  - remove the piece of code that checks whether specialities have come from Contentful before displaying it (this is now a required field in the content model)
- alter the order of services & specialities on CaseStudyHero - services now come first, as this is the umbrella term above specialities
- alter the "We work with" section of the service template, to account for the fact that the design page now has only 1 column and no subtitles

Note: most of the work for this trello ticket were things to be done directly within Contentful

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
