### PR TITLE
Technology partnerships

### DIFF
--- a/src/components/AboutUs/PaddedCol.js
+++ b/src/components/AboutUs/PaddedCol.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+import breakpoint from 'styled-components-breakpoint'
+
+import { Col } from '../grid'
+
+const PaddedCol = styled(Col).attrs({ block: false })`
+  flex-direction: column;
+  align-items: flex-start;
+
+  ${breakpoint('smallPhone')`
+    padding-bottom: ${props => props.theme.spacing[3]}
+    &:last-child {
+      padding-bottom: 0
+    }
+  `}
+  ${breakpoint('tablet')`
+    padding-bottom: 0
+  `}
+`
+
+export default PaddedCol

--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -38,7 +38,11 @@ const Partners = ({ partnershipsTitle, partners }) => (
             block={false}
             width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}
           >
-            <Image image={partner.image} width="250px" />
+            <Image
+              image={partner.image}
+              width="250px"
+              style={{ filter: 'grayscale(1)', saturate: '0' }}
+            />
           </PaddedCol>
         ))}
       </Row>

--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -1,29 +1,13 @@
 import React from 'react'
-import styled from 'styled-components'
-import breakpoint from 'styled-components-breakpoint'
 import { Padding } from 'styled-components-spacing'
 
 import Image from '../Common/Image'
-import { Grid, Col, Row } from '../grid'
+import { Grid, Row } from '../grid'
 import { SectionTitle } from '../Typography'
-
-const PaddedCol = styled(Col)`
-  flex-direction: column;
-  align-items: flex-start;
-
-  ${breakpoint('smallPhone')`
-    padding-bottom: ${props => props.theme.spacing[1]}
-    &:last-child {
-      padding-bottom: 0
-    }
-  `}
-  ${breakpoint('tablet')`
-    padding-bottom: 0
-  `}
-`
+import PaddedCol from './PaddedCol'
 
 const Partner = ({ image }) => (
-  <PaddedCol block={false} width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}>
+  <PaddedCol width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}>
     <Image
       image={image}
       width="250px"

--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -22,7 +22,7 @@ const PaddedCol = styled(Col)`
   `}
 `
 
-const PartnersSection = ({ partnershipsTitle, partners }) => (
+const Partners = ({ partnershipsTitle, partners }) => (
   <Grid>
     <Padding
       top={{ smallPhone: 3, tablet: 4 }}
@@ -46,4 +46,4 @@ const PartnersSection = ({ partnershipsTitle, partners }) => (
   </Grid>
 )
 
-export default PartnersSection
+export default Partners

--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -22,14 +22,14 @@ const PaddedCol = styled(Col)`
   `}
 `
 
-const Partners = ({ partnershipsTitle, partners }) => (
+const Partners = ({ title, partners }) => (
   <Grid>
     <Padding
       top={{ smallPhone: 3, tablet: 4 }}
       bottom={{ smallPhone: 3.5, tablet: 5 }}
     >
       <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
-        <SectionTitle>{partnershipsTitle}</SectionTitle>
+        <SectionTitle>{title}</SectionTitle>
       </Padding>
       <Row>
         {partners.map((partner, idx) => (

--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -22,6 +22,16 @@ const PaddedCol = styled(Col)`
   `}
 `
 
+const Partner = ({ image }) => (
+  <PaddedCol block={false} width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}>
+    <Image
+      image={image}
+      width="250px"
+      style={{ filter: 'grayscale(1)', saturate: '0' }}
+    />
+  </PaddedCol>
+)
+
 const Partners = ({ title, partners }) => (
   <Grid>
     <Padding
@@ -33,17 +43,7 @@ const Partners = ({ title, partners }) => (
       </Padding>
       <Row>
         {partners.map((partner, idx) => (
-          <PaddedCol
-            key={idx}
-            block={false}
-            width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}
-          >
-            <Image
-              image={partner.image}
-              width="250px"
-              style={{ filter: 'grayscale(1)', saturate: '0' }}
-            />
-          </PaddedCol>
+          <Partner key={idx} image={partner.image} />
         ))}
       </Row>
     </Padding>

--- a/src/components/AboutUs/PartnersSection.js
+++ b/src/components/AboutUs/PartnersSection.js
@@ -4,14 +4,15 @@ import breakpoint from 'styled-components-breakpoint'
 import { Padding } from 'styled-components-spacing'
 
 import Image from '../Common/Image'
-import { Grid, ColumnLayout, Col } from '../grid'
+import { Grid, Col, Row } from '../grid'
 import { SectionTitle } from '../Typography'
 
 const PaddedCol = styled(Col)`
   flex-direction: column;
   align-items: flex-start;
+
   ${breakpoint('smallPhone')`
-    padding-bottom: ${props => props.theme.spacing[3]}
+    padding-bottom: ${props => props.theme.spacing[1]}
     &:last-child {
       padding-bottom: 0
     }
@@ -30,16 +31,17 @@ const PartnersSection = ({ partnershipsTitle, partners }) => (
       <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
         <SectionTitle>{partnershipsTitle}</SectionTitle>
       </Padding>
-      <ColumnLayout cols={4} items={partners}>
-        {({ Col, item: partner }) => {
-          const { image } = partner
-          return (
-            <PaddedCol block={false}>
-              <Image image={image} />
-            </PaddedCol>
-          )
-        }}
-      </ColumnLayout>
+      <Row>
+        {partners.map((partner, idx) => (
+          <PaddedCol
+            key={idx}
+            block={false}
+            width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}
+          >
+            <Image image={partner.image} width="250px" />
+          </PaddedCol>
+        ))}
+      </Row>
     </Padding>
   </Grid>
 )

--- a/src/components/AboutUs/PartnersSection.js
+++ b/src/components/AboutUs/PartnersSection.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+import breakpoint from 'styled-components-breakpoint'
+import { Padding } from 'styled-components-spacing'
+
+import Image from '../Common/Image'
+import { Grid, ColumnLayout, Col } from '../grid'
+import { SectionTitle } from '../Typography'
+
+const PaddedCol = styled(Col)`
+  flex-direction: column;
+  align-items: flex-start;
+  ${breakpoint('smallPhone')`
+    padding-bottom: ${props => props.theme.spacing[3]}
+    &:last-child {
+      padding-bottom: 0
+    }
+  `}
+  ${breakpoint('tablet')`
+    padding-bottom: 0
+  `}
+`
+
+const PartnersSection = ({ partnershipsTitle, partners }) => (
+  <Grid>
+    <Padding
+      top={{ smallPhone: 3, tablet: 4 }}
+      bottom={{ smallPhone: 3.5, tablet: 5 }}
+    >
+      <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
+        <SectionTitle>{partnershipsTitle}</SectionTitle>
+      </Padding>
+      <ColumnLayout cols={4} items={partners}>
+        {({ Col, item: partner }) => {
+          const { image } = partner
+          return (
+            <PaddedCol block={false}>
+              <Image image={image} />
+            </PaddedCol>
+          )
+        }}
+      </ColumnLayout>
+    </Padding>
+  </Grid>
+)
+
+export default PartnersSection

--- a/src/components/AboutUs/Subsidiaries.js
+++ b/src/components/AboutUs/Subsidiaries.js
@@ -1,31 +1,15 @@
 import React from 'react'
-import styled from 'styled-components'
-import breakpoint from 'styled-components-breakpoint'
 import { Padding } from 'styled-components-spacing'
 
 import BlueBackground from '../Common/BlueBackground'
 import Image from '../Common/Image'
-import { Grid, Row, Col } from '../grid'
+import { Grid, Row } from '../grid'
 import { SectionTitle, BodyPrimary } from '../Typography'
 import StyledLink from '../Common/StyledLink'
-
-const PaddedCol = styled(Col)`
-  flex-direction: column;
-  align-items: flex-start;
-
-  ${breakpoint('smallPhone')`
-    padding-bottom: ${props => props.theme.spacing[3]}
-    &:last-child {
-      padding-bottom: 0
-    }
-  `}
-  ${breakpoint('tablet')`
-    padding-bottom: 0
-  `}
-`
+import PaddedCol from './PaddedCol'
 
 const Subsidiary = ({ image, description, linkUrl, linkText }) => (
-  <PaddedCol block={false} width={[1, 1, 1, 1, 1 / 2]}>
+  <PaddedCol width={[1, 1, 1, 1, 1 / 2]}>
     <Image image={image} width="250px" />
     <BodyPrimary reverse muted>
       {description}

--- a/src/components/AboutUs/Subsidiaries.js
+++ b/src/components/AboutUs/Subsidiaries.js
@@ -1,11 +1,11 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import breakpoint from 'styled-components-breakpoint'
 import { Padding } from 'styled-components-spacing'
 
 import BlueBackground from '../Common/BlueBackground'
 import Image from '../Common/Image'
-import { Grid, ColumnLayout, Col } from '../grid'
+import { Grid, Row, Col } from '../grid'
 import { SectionTitle, BodyPrimary } from '../Typography'
 import StyledLink from '../Common/StyledLink'
 
@@ -25,7 +25,7 @@ const PaddedCol = styled(Col)`
 `
 
 const Subsidiary = ({ image, description, linkUrl, linkText }) => (
-  <Fragment>
+  <PaddedCol block={false} width={[1, 1, 1, 1, 1 / 2]}>
     <Image image={image} width="250px" />
     <BodyPrimary reverse muted>
       {description}
@@ -35,7 +35,7 @@ const Subsidiary = ({ image, description, linkUrl, linkText }) => (
         {linkText}
       </StyledLink>
     ) : null}
-  </Fragment>
+  </PaddedCol>
 )
 
 const Subsidiaries = ({ title, subsidiaries }) => (
@@ -48,8 +48,8 @@ const Subsidiaries = ({ title, subsidiaries }) => (
         <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
           <SectionTitle reverse>{title}</SectionTitle>
         </Padding>
-        <ColumnLayout cols={2} items={subsidiaries}>
-          {({ Col, item: subsidiary }) => {
+        <Row>
+          {subsidiaries.map((subsidiary, idx) => {
             const {
               description: { description },
               image,
@@ -58,17 +58,16 @@ const Subsidiaries = ({ title, subsidiaries }) => (
             } = subsidiary
 
             return (
-              <PaddedCol block={false}>
-                <Subsidiary
-                  image={image}
-                  description={description}
-                  linkText={linkText}
-                  linkUrl={linkUrl}
-                />
-              </PaddedCol>
+              <Subsidiary
+                key={idx}
+                image={image}
+                description={description}
+                linkText={linkText}
+                linkUrl={linkUrl}
+              />
             )
-          }}
-        </ColumnLayout>
+          })}
+        </Row>
       </Padding>
     </Grid>
   </BlueBackground>

--- a/src/pages/about-us.js
+++ b/src/pages/about-us.js
@@ -5,15 +5,27 @@ import Layout from '../components/layout'
 import Head from '../components/Common/Head'
 import Subsidiaries from '../components/AboutUs/Subsidiaries'
 import Teams from '../components/AboutUs/Teams'
+import PartnersSection from '../components/AboutUs/PartnersSection'
 
 const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
-  const { yldGroupTitle, subsidiaries, teamSectionTitle, teams } = content
+  const {
+    teamSectionTitle,
+    teams,
+    yldGroupTitle,
+    subsidiaries,
+    partnershipsTitle,
+    partners
+  } = content
 
   return (
     <Layout>
       <Head page={content} />
-      <Subsidiaries title={yldGroupTitle} subsidiaries={subsidiaries} />
       <Teams title={teamSectionTitle} teams={teams} />
+      <Subsidiaries title={yldGroupTitle} subsidiaries={subsidiaries} />
+      <PartnersSection
+        partnershipsTitle={partnershipsTitle}
+        partners={partners}
+      />
     </Layout>
   )
 }
@@ -91,6 +103,9 @@ const AboutUsPage = props => (
               title
               file {
                 url
+              }
+              fluid(maxWidth: 250) {
+                ...GatsbyContentfulFluid_withWebp
               }
             }
           }

--- a/src/pages/about-us.js
+++ b/src/pages/about-us.js
@@ -22,7 +22,7 @@ const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
       <Head page={content} />
       <Teams title={teamSectionTitle} teams={teams} />
       <Subsidiaries title={yldGroupTitle} subsidiaries={subsidiaries} />
-      <Partners partnershipsTitle={partnershipsTitle} partners={partners} />
+      <Partners title={partnershipsTitle} partners={partners} />
     </Layout>
   )
 }

--- a/src/pages/about-us.js
+++ b/src/pages/about-us.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout'
 import Head from '../components/Common/Head'
 import Subsidiaries from '../components/AboutUs/Subsidiaries'
 import Teams from '../components/AboutUs/Teams'
-import PartnersSection from '../components/AboutUs/PartnersSection'
+import Partners from '../components/AboutUs/Partners'
 
 const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
   const {
@@ -22,10 +22,7 @@ const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
       <Head page={content} />
       <Teams title={teamSectionTitle} teams={teams} />
       <Subsidiaries title={yldGroupTitle} subsidiaries={subsidiaries} />
-      <PartnersSection
-        partnershipsTitle={partnershipsTitle}
-        partners={partners}
-      />
+      <Partners partnershipsTitle={partnershipsTitle} partners={partners} />
     </Layout>
   )
 }


### PR DESCRIPTION
## Technology partnerships page section - [Trello ticket](https://trello.com/c/ahG6KZbx/398-5-reuse-4-column-grid-logo-grid-for-our-partnerships)

- Created `Partners` sub component for About Us page
- Re-used `PaddedCol` pattern from Subsidiaries section, but didn't use `ColumnLayout` this time

FYI, looks like this if a 5th gets added

---

![image](https://user-images.githubusercontent.com/15656538/53028823-8803d200-345f-11e9-8f7c-f18218e34f73.png)

---

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
