### PR TITLE
create AboutUsHero section & add necessary content fields to Contentful query

### DIFF
--- a/src/components/AboutUs/AboutUsHero.js
+++ b/src/components/AboutUs/AboutUsHero.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Padding } from 'styled-components-spacing'
+
+import { Grid, Row, Col } from '../grid'
+import PaddedCol from './PaddedCol'
+import Image from '../Common/Image'
+import { SectionTitle, BodyPrimary } from '../Typography'
+
+const SupportingStatement = ({ icon, text }) => (
+  <PaddedCol width={[1, 1, 1, 1, 1 / 2, 1 / 3]}>
+    <Padding bottom={1}>
+      <Image image={icon} width="50px" />
+    </Padding>
+    <BodyPrimary>{text}</BodyPrimary>
+  </PaddedCol>
+)
+
+const AboutUsHero = ({
+  statementText,
+  supportingStatement1Icon,
+  supportingStatement1Text,
+  supportingStatement2Icon,
+  supportingStatement2Text,
+  supportingStatement3Icon,
+  supportingStatement3Text
+}) => (
+  <Grid>
+    <Padding
+      top={{ smallPhone: 3.5, tablet: 5 }}
+      bottom={{ smallPhone: 3.5, tablet: 5 }}
+    >
+      <Row>
+        <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
+          <Col width={[1, 1, 1, 1, 8 / 12, 10 / 12, 8 / 12]}>
+            <SectionTitle>{statementText}</SectionTitle>
+          </Col>
+        </Padding>
+      </Row>
+      <Row>
+        <SupportingStatement
+          icon={supportingStatement1Icon}
+          text={supportingStatement1Text}
+        />
+        <SupportingStatement
+          icon={supportingStatement2Icon}
+          text={supportingStatement2Text}
+        />
+        <SupportingStatement
+          icon={supportingStatement3Icon}
+          text={supportingStatement3Text}
+        />
+      </Row>
+    </Padding>
+  </Grid>
+)
+
+export default AboutUsHero

--- a/src/components/AboutUs/AboutUsHero.js
+++ b/src/components/AboutUs/AboutUsHero.js
@@ -15,15 +15,7 @@ const SupportingStatement = ({ icon, text }) => (
   </PaddedCol>
 )
 
-const AboutUsHero = ({
-  statementText,
-  supportingStatement1Icon,
-  supportingStatement1Text,
-  supportingStatement2Icon,
-  supportingStatement2Text,
-  supportingStatement3Icon,
-  supportingStatement3Text
-}) => (
+const AboutUsHero = ({ statementText, supportingStatements }) => (
   <Grid>
     <Padding
       top={{ smallPhone: 3.5, tablet: 5 }}
@@ -37,18 +29,13 @@ const AboutUsHero = ({
         </Padding>
       </Row>
       <Row>
-        <SupportingStatement
-          icon={supportingStatement1Icon}
-          text={supportingStatement1Text}
-        />
-        <SupportingStatement
-          icon={supportingStatement2Icon}
-          text={supportingStatement2Text}
-        />
-        <SupportingStatement
-          icon={supportingStatement3Icon}
-          text={supportingStatement3Text}
-        />
+        {supportingStatements.map((supportingStatement, idx) => (
+          <SupportingStatement
+            key={idx}
+            icon={supportingStatement.icon}
+            text={supportingStatement.text}
+          />
+        ))}
       </Row>
     </Padding>
   </Grid>

--- a/src/pages/about-us.js
+++ b/src/pages/about-us.js
@@ -25,17 +25,27 @@ const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
     partners
   } = content
 
+  const supportingStatements = [
+    {
+      icon: supportingStatement1Icon,
+      text: supportingStatement1Text
+    },
+    {
+      icon: supportingStatement2Icon,
+      text: supportingStatement2Text
+    },
+    {
+      icon: supportingStatement3Icon,
+      text: supportingStatement3Text
+    }
+  ]
+
   return (
     <Layout>
       <Head page={content} />
       <AboutUsHero
         statementText={statementText}
-        supportingStatement1Icon={supportingStatement1Icon}
-        supportingStatement1Text={supportingStatement1Text}
-        supportingStatement2Icon={supportingStatement2Icon}
-        supportingStatement2Text={supportingStatement2Text}
-        supportingStatement3Icon={supportingStatement3Icon}
-        supportingStatement3Text={supportingStatement3Text}
+        supportingStatements={supportingStatements}
       />
       <Teams title={teamSectionTitle} teams={teams} />
       <Subsidiaries title={yldGroupTitle} subsidiaries={subsidiaries} />

--- a/src/pages/about-us.js
+++ b/src/pages/about-us.js
@@ -3,12 +3,20 @@ import { StaticQuery, graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import Head from '../components/Common/Head'
+import AboutUsHero from '../components/AboutUs/AboutUsHero'
 import Subsidiaries from '../components/AboutUs/Subsidiaries'
 import Teams from '../components/AboutUs/Teams'
 import Partners from '../components/AboutUs/Partners'
 
 const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
   const {
+    statementText,
+    supportingStatement1Icon,
+    supportingStatement1Text,
+    supportingStatement2Icon,
+    supportingStatement2Text,
+    supportingStatement3Icon,
+    supportingStatement3Text,
     teamSectionTitle,
     teams,
     yldGroupTitle,
@@ -20,6 +28,15 @@ const AboutUs = ({ data: { contentfulAboutUsPage: content } }) => {
   return (
     <Layout>
       <Head page={content} />
+      <AboutUsHero
+        statementText={statementText}
+        supportingStatement1Icon={supportingStatement1Icon}
+        supportingStatement1Text={supportingStatement1Text}
+        supportingStatement2Icon={supportingStatement2Icon}
+        supportingStatement2Text={supportingStatement2Text}
+        supportingStatement3Icon={supportingStatement3Icon}
+        supportingStatement3Text={supportingStatement3Text}
+      />
       <Teams title={teamSectionTitle} teams={teams} />
       <Subsidiaries title={yldGroupTitle} subsidiaries={subsidiaries} />
       <Partners title={partnershipsTitle} partners={partners} />
@@ -35,6 +52,37 @@ const AboutUsPage = props => (
           title
           seoTitle
           seoDescription
+          statementText
+          supportingStatement1Icon {
+            title
+            file {
+              url
+            }
+            fluid(maxWidth: 30) {
+              ...GatsbyContentfulFluid_withWebp
+            }
+          }
+          supportingStatement1Text
+          supportingStatement2Icon {
+            title
+            file {
+              url
+            }
+            fluid(maxWidth: 30) {
+              ...GatsbyContentfulFluid_withWebp
+            }
+          }
+          supportingStatement2Text
+          supportingStatement3Icon {
+            title
+            file {
+              url
+            }
+            fluid(maxWidth: 30) {
+              ...GatsbyContentfulFluid_withWebp
+            }
+          }
+          supportingStatement3Text
           teamSectionTitle
           teams {
             name


### PR DESCRIPTION
## AboutUsHero section - [Trello ticket](https://trello.com/c/DceUHQYf/394-5-hero-section)

- Added "statement text" & "supporting statement" blocks to Contentful query  
(Note: the number of "supporting statements" is hard-coded in Contentful - see trello ticket for product reqs)
- Created component for hero section

---

FYI, I didn't use the `Statement` component after all because it turns out there a fair few fundamental differences:

|  | `Statement` component | `AboutUsHero` |
| -- | -- | -- |
| Background colour | Grey | White |
| Text colour | Grey | Black |
| Typography | `DisplayTitle` | `SectionTitle` (slight error in Zeplin designs for size on mobile, but I checked with Antonas) |
| Column width | <li>small tablet = 10</li><li>largeTablet = 10</li><li>desktop = 9</li> | <li>small tablet = 8</li><li>largeTablet = 10</li><li>desktop = 8</li> |


## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
