### PR TITLE
Fix contact us page layout

### DIFF
--- a/src/components/Common/Button.js
+++ b/src/components/Common/Button.js
@@ -12,7 +12,7 @@ const Button = styled.button`
   line-height: ${remcalc(24)};
   box-sizing: border-box;
 
-  :disabled {
+  &:disabled {
     opacity: 0.5;
   }
 `

--- a/src/components/Common/Button.js
+++ b/src/components/Common/Button.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+import remcalc from 'remcalc'
+
+const Button = styled.button`
+  border: 0;
+  display: block;
+  padding: ${remcalc(18)} ${remcalc(24)};
+  color: ${props => props.theme.colors.white};
+  background: ${props => props.theme.colors.text};
+  font-weight: bold;
+  font-size: ${remcalc(18)};
+  line-height: ${remcalc(24)};
+  box-sizing: border-box;
+
+  :disabled {
+    opacity: 0.5;
+  }
+`
+
+export default Button

--- a/src/components/Common/Button.js
+++ b/src/components/Common/Button.js
@@ -1,8 +1,13 @@
 import styled from 'styled-components'
 import remcalc from 'remcalc'
 
-const Button = styled.button`
-  border: 0;
+export const UnstyledButton = styled.button`
+  border: none;
+  background: transparent;
+  padding: 0;
+`
+
+const Button = styled(UnstyledButton)`
   display: block;
   padding: ${remcalc(18)} ${remcalc(24)};
   color: ${props => props.theme.colors.white};

--- a/src/components/Common/Forms.js
+++ b/src/components/Common/Forms.js
@@ -47,22 +47,6 @@ export const Label = styled('label')`
   display: block;
 `
 
-export const Button = styled.button`
-  border: 0;
-  display: block;
-  padding: ${remcalc(18)} ${remcalc(24)};
-  color: ${props => props.theme.colors.white};
-  background: ${props => props.theme.colors.text};
-  font-weight: bold;
-  font-size: ${remcalc(18)};
-  line-height: ${remcalc(24)};
-  box-sizing: border-box;
-
-  :disabled {
-    opacity: 0.5;
-  }
-`
-
 export const Field = styled.section`
   margin-bottom: ${remcalc(36)};
 

--- a/src/components/Common/Tab.js
+++ b/src/components/Common/Tab.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import remcalc from 'remcalc'
 import is from 'styled-is'
-import UnstyledButton from './UnstyledButton'
+import { UnstyledButton } from './Button'
 import { Subtitle } from '../Typography'
 
 const TabContainer = styled.li`

--- a/src/components/Common/UnstyledButton.js
+++ b/src/components/Common/UnstyledButton.js
@@ -1,9 +1,0 @@
-import styled from 'styled-components'
-
-const UnstyledButton = styled.button`
-  border: none;
-  background: transparent;
-  padding: 0;
-`
-
-export default UnstyledButton

--- a/src/components/ContactUs/AreasOfInterest.js
+++ b/src/components/ContactUs/AreasOfInterest.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import styled from 'styled-components'
+import remcalc from 'remcalc'
+import { Padding } from 'styled-components-spacing'
+
+import { Row, Col } from '../grid'
+import { Label, Checkbox } from '../Common/Forms'
+
+export const CheckBoxesContainer = styled(Col)`
+  display: flex;
+  flex-flow: row wrap;
+  margin-bottom: ${remcalc(36)};
+
+  /* Since these columns are inside a column,
+     we have to reset the padding on the edges */
+  > * {
+    display: flex;
+    align-items: center;
+    margin-bottom: ${remcalc(24)};
+
+    &:nth-child(odd) {
+      padding-left: 0;
+    }
+
+    &:nth-child(even) {
+      padding-right: 0;
+    }
+  }
+`
+
+const AreasOfInterest = ({ title, interests, onChange }) => (
+  <section>
+    <Row>
+      <Col width={[1, 1, 1, 1, 8 / 12, 7 / 12]}>
+        <Padding bottom={1}>
+          <Label>{title}</Label>
+        </Padding>
+      </Col>
+    </Row>
+    <Row>
+      <CheckBoxesContainer width={[1, 1, 1, 1, 10 / 12, 8 / 12]}>
+        {interests.map((interest, idx) => {
+          const { name, label } = interest
+          return (
+            <Col width={[1, 1, 1, 1, 6 / 12]} key={idx}>
+              <Checkbox
+                type="checkbox"
+                id={name}
+                name={name}
+                onChange={onChange}
+              />
+              <label htmlFor={name}>{label}</label>
+            </Col>
+          )
+        })}
+      </CheckBoxesContainer>
+    </Row>
+  </section>
+)
+
+export default AreasOfInterest

--- a/src/components/ContactUs/ThankYouMessage.js
+++ b/src/components/ContactUs/ThankYouMessage.js
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { Row, Col } from '../grid'
+import { BodyPrimary } from '../Typography'
+
+const ThankYouMessage = ({ message }) => (
+  <Row>
+    <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
+      <BodyPrimary>{message}</BodyPrimary>
+    </Col>
+  </Row>
+)
+
+export default ThankYouMessage

--- a/src/components/ContactUs/TitleSection.js
+++ b/src/components/ContactUs/TitleSection.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Padding } from 'styled-components-spacing'
+
+import { Grid, Row, Col } from '../grid'
+import { SectionTitle } from '../Typography'
+
+const TitleSection = ({ title }) => (
+  <Grid>
+    <Padding
+      top={{ smallPhone: 3, tablet: 4 }}
+      bottom={{ smallPhone: 3, tablet: 4 }}
+    >
+      <Row>
+        <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
+          <SectionTitle as="h1">{title}</SectionTitle>
+        </Col>
+      </Row>
+    </Padding>
+  </Grid>
+)
+
+export default TitleSection

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 import remcalc from 'remcalc'
 
 import { SectionTitle, BodyPrimary } from '../components/Typography'
-import { Button } from '../components/forms'
+import Button from '../components/Common/Button'
 import Layout from '../components/layout'
 
 const HomePageLink = styled(Button)`

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import remcalc from 'remcalc'
 import styled from 'styled-components'
 import { StaticQuery, graphql, Link } from 'gatsby'
@@ -7,24 +7,23 @@ import { Grid, Row, Col } from '../components/grid'
 import Layout from '../components/layout'
 import Head from '../components/Common/Head'
 import { SectionTitle, BodyPrimary } from '../components/Typography'
-import { Checkbox, Input, Label, Button, Field } from '../components/forms'
+import { Checkbox, Input, Label, Field } from '../components/Common/Forms'
+import Button from '../components/Common/Button'
 import GreyBackground from '../components/GreyBG'
 
-const Success = () => (
-  <Fragment>
-    <Row>
-      <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
-        <SectionTitle>We will be in touch</SectionTitle>
-      </Col>
-    </Row>
-    <Row>
-      <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
-        <BodyPrimary>
-          Thanks for reaching out. We will be in contact shortly
-        </BodyPrimary>
-      </Col>
-    </Row>
-  </Fragment>
+const TitleSection = ({ title }) => (
+  <Grid>
+    <Padding
+      top={{ smallPhone: 3, tablet: 4 }}
+      bottom={{ smallPhone: 3, tablet: 4 }}
+    >
+      <Row>
+        <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
+          <SectionTitle as="h1">{title}</SectionTitle>
+        </Col>
+      </Row>
+    </Padding>
+  </Grid>
 )
 
 export const CheckBoxesContainer = styled(Col)`
@@ -124,18 +123,9 @@ class ContactUs extends Component {
     return (
       <Layout location={location}>
         <Head page={page} />
-        <Grid>
-          <Padding
-            top={{ smallPhone: 3, tablet: 4 }}
-            bottom={{ smallPhone: 3, tablet: 4 }}
-          >
-            <Row>
-              <Col width={[8 / 12]}>
-                <SectionTitle as="h1">Get in touch</SectionTitle>
-              </Col>
-            </Row>
-          </Padding>
-        </Grid>
+        <TitleSection
+          title={success ? 'We will be in touch' : 'Get in touch'}
+        />
         <GreyBackground>
           <Grid>
             <Padding
@@ -143,7 +133,13 @@ class ContactUs extends Component {
               bottom={{ smallPhone: 3.5, tablet: 5 }}
             >
               {success ? (
-                <Success />
+                <Row>
+                  <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
+                    <BodyPrimary>
+                      Thanks for reaching out. We will be in contact shortly
+                    </BodyPrimary>
+                  </Col>
+                </Row>
               ) : (
                 <form
                   name="contact"

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -124,116 +124,123 @@ class ContactUs extends Component {
     return (
       <Layout location={location}>
         <Head page={page} />
+        <Grid>
+          <Padding
+            top={{ smallPhone: 3, tablet: 4 }}
+            bottom={{ smallPhone: 3, tablet: 4 }}
+          >
+            <Row>
+              <Col width={[8 / 12]}>
+                <SectionTitle as="h1">Get in touch</SectionTitle>
+              </Col>
+            </Row>
+          </Padding>
+        </Grid>
         <GreyBackground>
-          <Grid mt={4}>
-            {success ? (
-              <Success />
-            ) : (
-              <Fragment>
-                <SectionTitle as="h1" style={{ transform: 'translateY(20%)' }}>
-                  Get in touch
-                </SectionTitle>
-                <Margin top={2}>
-                  <form
-                    name="contact"
-                    method="post"
-                    data-netlify="true"
-                    data-netlify-honeypot="bot-field"
-                    onSubmit={this.handleSubmit}
-                    style={{ width: '100%' }}
-                  >
-                    <input type="hidden" name="form-name" value="contact" />
-                    <Row mt={2}>
-                      <Col width={[1, 1, 1, 1, 8 / 12, 7 / 12]}>
-                        <Margin bottom={1}>
-                          <Label>What are you interested in?</Label>
-                        </Margin>
-                      </Col>
-                    </Row>
-                    <Row>
-                      <CheckBoxesContainer
-                        width={[1, 1, 1, 1, 10 / 12, 8 / 12]}
+          <Grid>
+            <Padding
+              top={{ smallPhone: 3, tablet: 4 }}
+              bottom={{ smallPhone: 3.5, tablet: 5 }}
+            >
+              {success ? (
+                <Success />
+              ) : (
+                <form
+                  name="contact"
+                  method="post"
+                  data-netlify="true"
+                  data-netlify-honeypot="bot-field"
+                  onSubmit={this.handleSubmit}
+                  style={{ width: '100%' }}
+                >
+                  <input type="hidden" name="form-name" value="contact" />
+                  <Row>
+                    <Col width={[1, 1, 1, 1, 8 / 12, 7 / 12]}>
+                      <Margin bottom={1}>
+                        <Label>What are you interested in?</Label>
+                      </Margin>
+                    </Col>
+                  </Row>
+                  <Row>
+                    <CheckBoxesContainer width={[1, 1, 1, 1, 10 / 12, 8 / 12]}>
+                      {checkboxes.map(c => (
+                        <Col width={[1, 1, 1, 1, 6 / 12]} key={c.name}>
+                          <Checkbox
+                            type="checkbox"
+                            id={c.name}
+                            name={c.name}
+                            onChange={this.handleChangeCheckbox}
+                          />
+                          <label htmlFor={c.name}>{c.label}</label>
+                        </Col>
+                      ))}
+                    </CheckBoxesContainer>
+                  </Row>
+                  <Row>
+                    <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 7 / 12]}>
+                      <Label htmlFor="message">Tell us a bit more</Label>
+                      <Input
+                        as="textarea"
+                        noBoxShadow={!this.state.triedSubmitting}
+                        rows="4"
+                        value={message}
+                        onChange={this.handleChange}
+                        placeholder="A brief description of what you’re looking for"
+                        id="message"
+                        name="message"
+                        required
+                      />
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 5 / 12]}>
+                      <Label htmlFor="name">Your Name</Label>
+                      <Input
+                        id="name"
+                        type="text"
+                        name="name"
+                        value={name}
+                        onChange={this.handleChange}
+                        required
+                      />
+                      <Label htmlFor="email">Your Email</Label>
+                      <Input
+                        id="email"
+                        type="email"
+                        name="email"
+                        value={email}
+                        onChange={this.handleChange}
+                        required
+                      />
+                      <Field>
+                        <section key="privacy">
+                          <Checkbox
+                            required
+                            type="checkbox"
+                            id="privacy"
+                            name="privacy"
+                            onChange={this.handleChangeCheckbox}
+                          />
+                          <label htmlFor="privacy">
+                            {"I agree to the terms of YLD's "}
+                            <LinkUnderline to={'/privacy-policy'}>
+                              privacy policy
+                            </LinkUnderline>
+                          </label>
+                        </section>
+                      </Field>
+                      <Button
+                        onClick={this.handleButtonClick}
+                        type="submit"
+                        disabled={submitting}
                       >
-                        {checkboxes.map(c => (
-                          <Col width={[1, 1, 1, 1, 6 / 12]} key={c.name}>
-                            <Checkbox
-                              type="checkbox"
-                              id={c.name}
-                              name={c.name}
-                              onChange={this.handleChangeCheckbox}
-                            />
-                            <label htmlFor={c.name}>{c.label}</label>
-                          </Col>
-                        ))}
-                      </CheckBoxesContainer>
-                    </Row>
-                    <Row>
-                      <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 7 / 12]}>
-                        <Label htmlFor="message">Tell us a bit more</Label>
-                        <Input
-                          as="textarea"
-                          noBoxShadow={!this.state.triedSubmitting}
-                          rows="4"
-                          value={message}
-                          onChange={this.handleChange}
-                          placeholder="A brief description of what you’re looking for"
-                          id="message"
-                          name="message"
-                          required
-                        />
-                      </Col>
-                    </Row>
-                    <Row>
-                      <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 5 / 12]}>
-                        <Label htmlFor="name">Your Name</Label>
-                        <Input
-                          id="name"
-                          type="text"
-                          name="name"
-                          value={name}
-                          onChange={this.handleChange}
-                          required
-                        />
-                        <Label htmlFor="email">Your Email</Label>
-                        <Input
-                          id="email"
-                          type="email"
-                          name="email"
-                          value={email}
-                          onChange={this.handleChange}
-                          required
-                        />
-                        <Field>
-                          <section key="privacy">
-                            <Checkbox
-                              required
-                              type="checkbox"
-                              id="privacy"
-                              name="privacy"
-                              onChange={this.handleChangeCheckbox}
-                            />
-                            <label htmlFor="privacy">
-                              {"I agree to the terms of YLD's "}
-                              <LinkUnderline to={'/privacy-policy'}>
-                                privacy policy
-                              </LinkUnderline>
-                            </label>
-                          </section>
-                        </Field>
-                        <Button
-                          onClick={this.handleButtonClick}
-                          type="submit"
-                          disabled={submitting}
-                        >
-                          {submitting ? 'Submitting' : 'Submit'}
-                        </Button>
-                      </Col>
-                    </Row>
-                  </form>
-                </Margin>
-              </Fragment>
-            )}
-            <Padding bottom={5} />
+                        {submitting ? 'Submitting' : 'Submit'}
+                      </Button>
+                    </Col>
+                  </Row>
+                </form>
+              )}
+            </Padding>
           </Grid>
         </GreyBackground>
       </Layout>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,54 +1,19 @@
-import React, { Component } from 'react'
-import remcalc from 'remcalc'
+import React, { Component, Fragment } from 'react'
 import styled from 'styled-components'
 import { StaticQuery, graphql, Link } from 'gatsby'
-import { Padding, Margin } from 'styled-components-spacing'
+import { Padding } from 'styled-components-spacing'
+
 import { Grid, Row, Col } from '../components/grid'
 import Layout from '../components/layout'
 import Head from '../components/Common/Head'
-import { SectionTitle, BodyPrimary } from '../components/Typography'
 import { Checkbox, Input, Label, Field } from '../components/Common/Forms'
 import Button from '../components/Common/Button'
 import GreyBackground from '../components/GreyBG'
+import TitleSection from '../components/ContactUs/TitleSection'
+import AreasOfInterest from '../components/ContactUs/AreasOfInterest'
+import ThankYouMessage from '../components/ContactUs/ThankYouMessage'
 
-const TitleSection = ({ title }) => (
-  <Grid>
-    <Padding
-      top={{ smallPhone: 3, tablet: 4 }}
-      bottom={{ smallPhone: 3, tablet: 4 }}
-    >
-      <Row>
-        <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
-          <SectionTitle as="h1">{title}</SectionTitle>
-        </Col>
-      </Row>
-    </Padding>
-  </Grid>
-)
-
-export const CheckBoxesContainer = styled(Col)`
-  display: flex;
-  flex-flow: row wrap;
-  margin-bottom: ${remcalc(36)};
-
-  /* Since these columns are inside a column,
-     we have to reset the padding on the edges */
-  > * {
-    display: flex;
-    align-items: center;
-    margin-bottom: ${remcalc(24)};
-
-    &:nth-child(odd) {
-      padding-left: 0;
-    }
-
-    &:nth-child(even) {
-      padding-right: 0;
-    }
-  }
-`
-
-const checkboxes = [
+const interests = [
   { name: 'engineering', label: 'Engineering services' },
   { name: 'design', label: 'Design services' },
   { name: 'training', label: 'Training services' },
@@ -123,122 +88,101 @@ class ContactUs extends Component {
     return (
       <Layout location={location}>
         <Head page={page} />
-        <TitleSection
-          title={success ? 'We will be in touch' : 'Get in touch'}
-        />
-        <GreyBackground>
-          <Grid>
-            <Padding
-              top={{ smallPhone: 3, tablet: 4 }}
-              bottom={{ smallPhone: 3.5, tablet: 5 }}
-            >
-              {success ? (
-                <Row>
-                  <Col width={[1, 1, 1, 8 / 12, 7 / 12]}>
-                    <BodyPrimary>
-                      Thanks for reaching out. We will be in contact shortly
-                    </BodyPrimary>
-                  </Col>
-                </Row>
-              ) : (
-                <form
-                  name="contact"
-                  method="post"
-                  data-netlify="true"
-                  data-netlify-honeypot="bot-field"
-                  onSubmit={this.handleSubmit}
-                  style={{ width: '100%' }}
-                >
-                  <input type="hidden" name="form-name" value="contact" />
-                  <Row>
-                    <Col width={[1, 1, 1, 1, 8 / 12, 7 / 12]}>
-                      <Margin bottom={1}>
-                        <Label>What are you interested in?</Label>
-                      </Margin>
-                    </Col>
-                  </Row>
-                  <Row>
-                    <CheckBoxesContainer width={[1, 1, 1, 1, 10 / 12, 8 / 12]}>
-                      {checkboxes.map(c => (
-                        <Col width={[1, 1, 1, 1, 6 / 12]} key={c.name}>
-                          <Checkbox
-                            type="checkbox"
-                            id={c.name}
-                            name={c.name}
-                            onChange={this.handleChangeCheckbox}
-                          />
-                          <label htmlFor={c.name}>{c.label}</label>
-                        </Col>
-                      ))}
-                    </CheckBoxesContainer>
-                  </Row>
-                  <Row>
-                    <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 7 / 12]}>
-                      <Label htmlFor="message">Tell us a bit more</Label>
-                      <Input
-                        as="textarea"
-                        noBoxShadow={!this.state.triedSubmitting}
-                        rows="4"
-                        value={message}
-                        onChange={this.handleChange}
-                        placeholder="A brief description of what you’re looking for"
-                        id="message"
-                        name="message"
-                        required
-                      />
-                    </Col>
-                  </Row>
-                  <Row>
-                    <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 5 / 12]}>
-                      <Label htmlFor="name">Your Name</Label>
-                      <Input
-                        id="name"
-                        type="text"
-                        name="name"
-                        value={name}
-                        onChange={this.handleChange}
-                        required
-                      />
-                      <Label htmlFor="email">Your Email</Label>
-                      <Input
-                        id="email"
-                        type="email"
-                        name="email"
-                        value={email}
-                        onChange={this.handleChange}
-                        required
-                      />
-                      <Field>
-                        <section key="privacy">
-                          <Checkbox
-                            required
-                            type="checkbox"
-                            id="privacy"
-                            name="privacy"
-                            onChange={this.handleChangeCheckbox}
-                          />
-                          <label htmlFor="privacy">
-                            {"I agree to the terms of YLD's "}
-                            <LinkUnderline to={'/privacy-policy'}>
-                              privacy policy
-                            </LinkUnderline>
-                          </label>
-                        </section>
-                      </Field>
-                      <Button
-                        onClick={this.handleButtonClick}
-                        type="submit"
-                        disabled={submitting}
-                      >
-                        {submitting ? 'Submitting' : 'Submit'}
-                      </Button>
-                    </Col>
-                  </Row>
-                </form>
-              )}
-            </Padding>
-          </Grid>
-        </GreyBackground>
+        <form
+          name="contact"
+          method="post"
+          data-netlify="true"
+          data-netlify-honeypot="bot-field"
+          onSubmit={this.handleSubmit}
+          style={{ width: '100%' }}
+        >
+          <input type="hidden" name="form-name" value="contact" />
+          <TitleSection
+            title={success ? 'We will be in touch' : 'Get in touch'}
+          />
+          <GreyBackground>
+            <Grid>
+              <Padding
+                top={{ smallPhone: 3, tablet: 4 }}
+                bottom={{ smallPhone: 3.5, tablet: 5 }}
+              >
+                {success ? (
+                  <ThankYouMessage message="Thanks for reaching out. We will be in contact shortly" />
+                ) : (
+                  <Fragment>
+                    <AreasOfInterest
+                      title="What are you interested in?"
+                      interests={interests}
+                      onChange={this.handleChangeCheckbox}
+                    />
+                    <Row>
+                      <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 7 / 12]}>
+                        <Label htmlFor="message">Tell us a bit more</Label>
+                        <Input
+                          as="textarea"
+                          noBoxShadow={!this.state.triedSubmitting}
+                          rows="4"
+                          value={message}
+                          onChange={this.handleChange}
+                          placeholder="A brief description of what you’re looking for"
+                          id="message"
+                          name="message"
+                          required
+                        />
+                      </Col>
+                    </Row>
+                    <Row>
+                      <Col width={[1, 1, 1, 1, 8 / 12, 8 / 12, 5 / 12]}>
+                        <Label htmlFor="name">Your Name</Label>
+                        <Input
+                          id="name"
+                          type="text"
+                          name="name"
+                          value={name}
+                          onChange={this.handleChange}
+                          required
+                        />
+                        <Label htmlFor="email">Your Email</Label>
+                        <Input
+                          id="email"
+                          type="email"
+                          name="email"
+                          value={email}
+                          onChange={this.handleChange}
+                          required
+                        />
+                        <Field>
+                          <section key="privacy">
+                            <Checkbox
+                              required
+                              type="checkbox"
+                              id="privacy"
+                              name="privacy"
+                              onChange={this.handleChangeCheckbox}
+                            />
+                            <label htmlFor="privacy">
+                              {"I agree to the terms of YLD's "}
+                              <LinkUnderline to={'/privacy-policy'}>
+                                privacy policy
+                              </LinkUnderline>
+                            </label>
+                          </section>
+                        </Field>
+                        <Button
+                          onClick={this.handleButtonClick}
+                          type="submit"
+                          disabled={submitting}
+                        >
+                          {submitting ? 'Submitting' : 'Submit'}
+                        </Button>
+                      </Col>
+                    </Row>
+                  </Fragment>
+                )}
+              </Padding>
+            </Grid>
+          </GreyBackground>
+        </form>
       </Layout>
     )
   }

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -4161,7 +4161,9 @@ exports[`Storyshots CustomisedBulletpoint CustomisedBulletpoint spaced 1`] = `
 
 exports[`Storyshots Form Button 1`] = `
 .c0 {
-  border: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
   display: block;
   padding: 1.125rem 1.5rem;
   color: #fff;

--- a/stories/form.stories.js
+++ b/stories/form.stories.js
@@ -5,10 +5,10 @@ import {
   Checkbox,
   Input,
   Label,
-  Button,
   Field,
   Fieldset
-} from '../src/components/forms'
+} from '../src/components/Common/Forms'
+import Button from '../src/components/Common/Button'
 
 addDecorator(Theme)
 


### PR DESCRIPTION
## Incorrect layout for Contact Us page - [Trello ticket](https://trello.com/c/rZ2HD9P6/419-contact-us-page-layout-doesnt-quite-conform-to-designs-where-grey-background-starts)

- Moved title into its own section with white background - now using a prop to change the text of the title, instead of having one `SectionTitle` inside `Success` & one `SectionTitle` inside the form
- Deleted `Success` component & moved `BodyPrimary` (success message text) directly into render method
- Removed `Margin`s from around Grid & used same `Padding` pattern that we use on other pages
- Fixed spacing above & below grey section, for all breakpoints

Refactor along the way:
- Moved `forms.js` from `/components` into `/components/Common`
- Moved `Button` component out from `forms.js`, into its own file, since it is used on the 404 page too & could get used elsewhere in future (we don't have another Button component atm)
- Separate `TitleSection`, `ThankYouMessage` & `AreasOfInterest` into separate files

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
