### PR TITLE
Remove arbitrary restriction on training modal's bullet point - make full width of container instead

### DIFF
--- a/src/components/Training/Modal.js
+++ b/src/components/Training/Modal.js
@@ -131,9 +131,7 @@ const CourseContent = ({ content }) => (
               <ul {...props} />
             </Padding>
           ),
-          listItem: props => (
-            <CustomisedBulletpoint style={{ maxWidth: 430 }} {...props} />
-          )
+          listItem: props => <CustomisedBulletpoint fullWidth {...props} />
         }}
         source={content.content.content}
       />


### PR DESCRIPTION
## Make training modal bullet point full width of container - [Trello ticket](https://trello.com/c/dBQYMJfh/354-2-modal-content-to-accept-both-subtitlebody-or-subtitle-custom-bullet-points)

Self explanatory

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
