### PR TITLE
bug: fix size of Course Catalog logos on training page

### DIFF
--- a/src/components/Training/Courses.js
+++ b/src/components/Training/Courses.js
@@ -24,7 +24,7 @@ const Courses = ({ categories, toggleModal }) => {
           <Col width={[1, 1, 1, 1, 1 / 2]} key={cat.id}>
             <Padding bottom={{ smallPhone: 3, tablet: 5 }}>
               <Padding bottom={1}>
-                <Image image={cat.logo} />
+                <Image image={cat.logo} width="60px" />
                 <SectionTitle>{cat.name}</SectionTitle>
               </Padding>
               <Flex column alignStart>


### PR DESCRIPTION
## fix size of Course Catalog logos on training page - [Trello ticket](https://trello.com/c/evogNraY/428-icons-on-training-catalog-section-of-training-page-are-too-large)

Specified `width` prop on `<Image>` tag

It's likely that this bug was introduced with [this change to our Image component](https://github.com/yldio/yld.io/pull/139/files#diff-4e0a3b6f61abaa95f516fc7202464543R23), when the About us PR was merged

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
