### PR TITLE
training modals - fix column layout & remove width restriction on CustomisedBulletpoint

### DIFF
--- a/src/components/Training/Modal.js
+++ b/src/components/Training/Modal.js
@@ -95,9 +95,9 @@ const ModalStyles = createGlobalStyle`
 `
 
 const CourseInfo = ({ content }) => (
-  <Col width={[1, 1, 1, 1, 1 / 2]}>
-    <Image image={content.logo} width="60px" />
+  <Col width={[1, 1, 1, 1, 5 / 6]} px={0}>
     <Padding bottom={1}>
+      <Image image={content.logo} width="60px" />
       <SectionTitle>{content.name}</SectionTitle>
     </Padding>
     {content.description && (
@@ -116,7 +116,7 @@ const CourseInfo = ({ content }) => (
 )
 
 const CourseContent = ({ content }) => (
-  <Col width={[1, 1, 1, 1, 1 / 2]}>
+  <Col width={[1, 1, 1, 1, 1, 5 / 6]} px={0}>
     <Padding top={4}>
       {/* eslint-disable react/display-name */}
       <ReactMarkdown
@@ -133,7 +133,7 @@ const CourseContent = ({ content }) => (
             </Padding>
           ),
           listItem: props => (
-            <CustomisedBulletpoint maxWidth="430px" {...props} />
+            <CustomisedBulletpoint maxWidth="auto" {...props} />
           )
         }}
         source={content.content.content}
@@ -153,8 +153,12 @@ const Modal = ({ content, toggleModal }) => (
         </Close>
         <Grid>
           <Row>
-            <CourseInfo content={content} />
-            <CourseContent content={content} />
+            <Col width={[1, 1, 1, 1, 1 / 2]}>
+              <CourseInfo content={content} />
+            </Col>
+            <Col width={[1, 1, 1, 1, 1 / 2]}>
+              <CourseContent content={content} />
+            </Col>
           </Row>
         </Grid>
       </Padding>


### PR DESCRIPTION
## training modals - fix column layout & remove width restriction on CustomisedBulletpoint - [Trello ticket](https://trello.com/c/UJ6SILfT/423-1-training-modals-fix-column-layout)

- remove width restriction from `CustomisedBulletpoint` on training page `Modal`
- instead restrict the width of the bullet points (and/or any other text) via the columns - i.e. bring Modal's column layout in line with design specs

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
