### PR TITLE
add extra padding above related case study on training page

### DIFF
--- a/src/pages/training.js
+++ b/src/pages/training.js
@@ -66,7 +66,7 @@ const TrainingPage = ({ data: { contentfulTrainingPage: content } }) => {
         title={`${content.contactUsTitle}`}
         contactText={content.contactUsText.contactUsText}
       />
-      <CaseStudyPreview caseStudy={content.relatedCaseStudy} />
+      <CaseStudyPreview isTop={false} caseStudy={content.relatedCaseStudy} />
     </Layout>
   )
 }


### PR DESCRIPTION
## Bug fix - [Trello ticket](https://trello.com/c/kF9AJY7j/447-casestudypreview-on-training-page-is-missing-top-padding)

Added missing `isTop` prop to the "related case study" on the training page, which puts top padding on the CaseStudy card.