### PR TITLE
fix: fix dropdown issues

### DIFF
--- a/src/components/Common/StyledLink.js
+++ b/src/components/Common/StyledLink.js
@@ -15,6 +15,7 @@ export const StyledLinkCss = css`
   position: relative;
   display: inline-block;
   transition: all ${props => props.theme.animations.fast} ease-out;
+  transition-property: background, color;
 
   &:after {
     content: '';

--- a/src/components/Header/SideNav/Dropdown.js
+++ b/src/components/Header/SideNav/Dropdown.js
@@ -19,6 +19,11 @@ const DropdownNameWrapper = styled.span.attrs(props => ({
   ${outlineStyles}
 
   ${props => props.states.default}
+
+  &:hover,
+  &:focus {
+    ${props => props.states.hoverActive}
+  }
 `
 
 const DropdownName = styled.span`
@@ -45,14 +50,11 @@ export default class Dropdown extends PureComponent {
   }
 
   toggle = e => {
+    e.preventDefault()
     this.setState({ isExpanded: !this.state.isExpanded })
   }
 
-  handleItemClick = () => {
-    this.setState({ isExpanded: false })
-  }
-
-  handleFocus = (e, ...rest) => {
+  handleFocus = () => {
     this.setState({ isExpanded: true })
   }
 
@@ -79,7 +81,6 @@ export default class Dropdown extends PureComponent {
                 href={href}
                 to={to}
                 activeClassName="active"
-                onClick={this.handleItemClick}
               >
                 {label}
               </InnerAnchorItem>

--- a/src/components/Header/SideNav/InnerAnchorItem.js
+++ b/src/components/Header/SideNav/InnerAnchorItem.js
@@ -19,30 +19,18 @@ const InnerAnchor = styled(Anchor)`
   width: 100%;
 
   background: ${props => props.theme.colors.greyBG};
-  color: ${props => props.theme.colors.text};
-  opacity: 0.5;
+  color: ${props => props.theme.colors.textLight};
 
   &:hover,
+  &:focus,
   &.active {
     color: ${props => props.theme.colors.text};
-    opacity: 1;
   }
 `
 
-export const InnerAnchorItem = ({
-  children,
-  to,
-  href,
-  activeClassName,
-  onClick
-}) => (
+export const InnerAnchorItem = ({ children, to, href, activeClassName }) => (
   <InnerListItem>
-    <InnerAnchor
-      href={href}
-      to={to}
-      activeClassName={activeClassName}
-      onClick={onClick}
-    >
+    <InnerAnchor href={href} to={to} activeClassName={activeClassName}>
       {children}
     </InnerAnchor>
   </InnerListItem>

--- a/src/components/Header/SideNav/outerItemStates.js
+++ b/src/components/Header/SideNav/outerItemStates.js
@@ -1,13 +1,11 @@
 import { css } from 'styled-components'
 
 const defaultStyles = css`
-  color: ${props => props.theme.colors.white};
-  opacity: 0.5;
+  color: ${props => props.theme.colors.textLight};
 `
 
 const hoverActiveStyles = css`
   color: ${props => props.theme.colors.white};
-  opacity: 1;
 `
 
 const outerItemStates = {

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -8,11 +8,9 @@ import InnerAnchorItem from './InnerAnchorItem'
 import headerItemStyles from '../headerItemStyles'
 import outlineStyles from '../outlineStyles'
 import topNavItemStyles from './topNavItemStyles'
-import { lightStates, darkStates } from './outerItemStates'
+import TopNavItem from './TopNavItem'
 
-const DropdownContainer = styled.li.attrs(props => ({
-  states: props.themeVariation === 'dark' ? darkStates : lightStates
-}))`
+const DropdownContainer = styled(TopNavItem)`
   position: relative;
   cursor: pointer;
   background: transparent;

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -44,9 +44,10 @@ const DropdownNameWrapper = styled.span`
   z-index: 2;
   ${headerItemStyles}
   ${topNavItemStyles}
-  ${outlineStyles}
+  ${props => !props.clicked && outlineStyles}
 
   ${props =>
+    props.clicked &&
     props.themeVariation === props.theme.variations.dark &&
     props.expanded === true &&
     css`
@@ -82,45 +83,50 @@ export default class Dropdown extends PureComponent {
   constructor(props) {
     super(props)
     this.state = {
-      isExpanded: false
+      isExpanded: false,
+      clicked: false
     }
-    this.ref = React.createRef()
   }
 
-  toggle = e => {
-    this.setState({ isExpanded: !this.state.isExpanded })
+  /**
+   * The outline is not desired when the user opens the dropdown with the mouse
+   * so we're detecting it on mouse down
+   */
+  handleMouseDown = () => {
+    this.setState({ clicked: true })
   }
 
-  handleItemClick = () => {
-    this.setState({ isExpanded: false })
+  handleItemClick = e => {
+    e.preventDefault()
+    this.setState({ clicked: false })
   }
 
-  handleFocus = (e, ...rest) => {
+  handleFocus = () => {
     this.setState({ isExpanded: true })
   }
 
   handleBlur = () => {
-    this.setState({ isExpanded: false })
+    this.setState({ isExpanded: false, clicked: false })
   }
 
   render() {
     const { items, themeVariation, children } = this.props
-    const { isExpanded } = this.state
+    const { isExpanded, clicked } = this.state
 
     return (
       <DropdownContainer
-        aria-haspopup="true"
         expanded={isExpanded}
+        aria-haspopup="true"
         aria-expanded={isExpanded}
-        onMouseDown={this.toggle}
         onFocus={this.handleFocus}
+        onMouseDown={this.handleMouseDown}
         onBlur={this.handleBlur}
         themeVariation={themeVariation}
-        ref={this.ref}
       >
         <DropdownNameWrapper
           tabIndex="0"
           expanded={isExpanded}
+          clicked={clicked}
           themeVariation={themeVariation}
         >
           <DropdownName>{children}</DropdownName>
@@ -134,7 +140,7 @@ export default class Dropdown extends PureComponent {
               href={href}
               to={to}
               activeClassName="active"
-              onClick={this.handleClick}
+              onMouseDown={this.handleItemClick}
             >
               {label}
             </InnerAnchorItem>

--- a/src/components/Header/TopNav/InnerAnchorItem.js
+++ b/src/components/Header/TopNav/InnerAnchorItem.js
@@ -17,7 +17,7 @@ const InnerAnchor = styled(Anchor)`
 
   width: 100%;
   background: ${props => props.theme.colors.greyBG};
-  color: ${props => props.theme.colors.text};
+  color: ${props => props.theme.colors.textLight};
 
   &:hover,
   &.active {

--- a/src/components/Header/TopNav/InnerAnchorItem.js
+++ b/src/components/Header/TopNav/InnerAnchorItem.js
@@ -8,24 +8,20 @@ import topNavItemStyles from './topNavItemStyles'
 
 const InnerListItem = styled.li`
   display: flex;
-  > a:focus {
-    ${outlineStyles}
-  }
 `
 
 const InnerAnchor = styled(Anchor)`
   ${headerItemStyles}
   ${topNavItemStyles}
-  width: 100%;
+  ${outlineStyles}
 
+  width: 100%;
   background: ${props => props.theme.colors.greyBG};
   color: ${props => props.theme.colors.text};
-  opacity: 0.5;
 
   &:hover,
   &.active {
     color: ${props => props.theme.colors.text};
-    opacity: 1;
   }
 `
 
@@ -35,7 +31,7 @@ export const InnerAnchorItem = ({
   href,
   activeClassName,
   themeVariation,
-  onClick,
+  onMouseDown,
   ...props
 }) => (
   <InnerListItem themeVariation={themeVariation} {...props}>
@@ -43,7 +39,7 @@ export const InnerAnchorItem = ({
       href={href}
       to={to}
       activeClassName={activeClassName}
-      onClick={onClick}
+      onMouseDown={onMouseDown}
     >
       {children}
     </InnerAnchor>

--- a/src/components/Header/TopNav/OuterAnchorItem.js
+++ b/src/components/Header/TopNav/OuterAnchorItem.js
@@ -11,19 +11,13 @@ const StyledAnchor = styled(Anchor)`
   ${headerItemStyles}
   ${topNavItemStyles}
 
-  &:focus {
-    ${outlineStyles}
-  }
+  ${outlineStyles}
 `
 
 const StyledListItem = styled.li.attrs(props => ({
   states: props.themeVariation === 'dark' ? darkStates : lightStates
 }))`
   display: flex;
-  &:focus {
-    ${outlineStyles}
-  }
-
   ${props => props.states.default}
 
   &:hover,

--- a/src/components/Header/TopNav/OuterAnchorItem.js
+++ b/src/components/Header/TopNav/OuterAnchorItem.js
@@ -5,7 +5,7 @@ import Anchor from '../../Common/Anchor'
 import headerItemStyles from '../headerItemStyles'
 import outlineStyles from '../outlineStyles'
 import topNavItemStyles from './topNavItemStyles'
-import { lightStates, darkStates } from './outerItemStates'
+import TopNavItem from './TopNavItem'
 
 const StyledAnchor = styled(Anchor)`
   ${headerItemStyles}
@@ -14,9 +14,7 @@ const StyledAnchor = styled(Anchor)`
   ${outlineStyles}
 `
 
-const StyledListItem = styled.li.attrs(props => ({
-  states: props.themeVariation === 'dark' ? darkStates : lightStates
-}))`
+const StyledListItem = styled(TopNavItem)`
   display: flex;
   ${props => props.states.default}
 

--- a/src/components/Header/TopNav/TopNavItem.js
+++ b/src/components/Header/TopNav/TopNavItem.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components'
+import remcalc from 'remcalc'
+
+import { lightStates, darkStates } from './outerItemStates'
+
+const TopNavItem = styled.li.attrs(props => ({
+  states: props.themeVariation === 'dark' ? darkStates : lightStates
+}))`
+  @media screen and (min-width: 960px) {
+    margin-right: ${remcalc(6)};
+
+    &:last-child {
+      margin-right: ${remcalc(0)};
+    }
+  }
+`
+
+export default TopNavItem

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -18,14 +18,6 @@ const TopNavList = styled.ul`
     flex: 1;
     padding: ${remcalc(20)} ${remcalc(0)} ${remcalc(16)};
     padding-right: ${remcalc(0)};
-
-    // Extra padding on top of spacing created by topNavItemStyles, to create extra space between list items
-    > li {
-      padding-right: ${remcalc(6)};
-    }
-    > li:last-child {
-      padding-right: ${remcalc(0)};
-    }
   }
 `
 

--- a/src/components/Header/TopNav/outerItemStates.js
+++ b/src/components/Header/TopNav/outerItemStates.js
@@ -3,61 +3,51 @@ import { css } from 'styled-components'
 const defaultLight = css`
   background: ${props => props.theme.colors.white};
   color: ${props => props.theme.colors.text};
-  opacity: 1;
 `
 
 const hoverLight = css`
   background: ${props => props.theme.colors.greyBG};
   color: ${props => props.theme.colors.text};
-  opacity: 1;
 `
 
 const clickTapLight = css`
   background: ${props => props.theme.colors.text};
   color: ${props => props.theme.colors.white};
-  opacity: 1;
 `
 
 const activeLight = css`
   background: ${props => props.theme.colors.white};
-  color: ${props => props.theme.colors.text};
-  opacity: 0.5;
+  color: ${props => props.theme.colors.textLight};
 `
 
 const activeAndHoverLight = css`
   background: ${props => props.theme.colors.text};
   color: #a9a9a9;
-  opacity: 1;
 `
 
 const defaultDark = css`
   background: ${props => props.theme.colors.blueBg};
   color: ${props => props.theme.colors.white};
-  opacity: 1;
 `
 
 const hoverDark = css`
   background: #3a3553;
   color: ${props => props.theme.colors.white};
-  opacity: 1;
 `
 
 const clickTapDark = css`
   background: ${props => props.theme.colors.vibrant};
   color: ${props => props.theme.colors.text};
-  opacity: 1;
 `
 
 const activeDark = css`
   background: ${props => props.theme.colors.blueBg};
-  color: ${props => props.theme.colors.white};
-  opacity: 0.7;
+  color: ${props => props.theme.colors.textLight};
 `
 
 const activeAndHoverDark = css`
   background: ${props => props.theme.colors.vibrant};
   color: #007f56;
-  opacity: 1;
 `
 
 export const lightStates = {

--- a/src/components/Header/TopNav/topNavItemStyles.js
+++ b/src/components/Header/TopNav/topNavItemStyles.js
@@ -5,8 +5,7 @@ const topNavItemStyles = css`
   font-weight: 400;
   font-size: ${remcalc(17)};
   line-height: ${remcalc(24)};
-  padding: ${remcalc(6)} ${remcalc(11)} ${remcalc(10)};
-  margin: ${remcalc(4)};
+  padding: ${remcalc(10)} ${remcalc(15)} ${remcalc(14)};
 `
 
 export default topNavItemStyles

--- a/src/components/Header/headerItemStyles.js
+++ b/src/components/Header/headerItemStyles.js
@@ -2,8 +2,7 @@ import { css } from 'styled-components'
 
 const headerItemStyles = css`
   transition: opacity ${props => props.theme.animations.fast} ease-out,
-    color ${props => props.theme.animations.fast} ease-out,
-    outline ${props => props.theme.animations.fast} ease-out;
+    color ${props => props.theme.animations.fast} ease-out;
   background: linear-gradient(to right, #616161 0%, transparent 0);
   outline: none;
 `

--- a/src/components/Header/outlineStyles.js
+++ b/src/components/Header/outlineStyles.js
@@ -2,8 +2,10 @@ import { css } from 'styled-components'
 import remcalc from 'remcalc'
 
 const outlineStyles = css`
+  outline: ${remcalc(4)} solid transparent;
   &:focus {
-    outline: ${remcalc(4)} solid ${props => props.theme.colors.vibrant};
+    outline-color: ${props => props.theme.colors.vibrant};
+    z-index: 1;
   }
 
   &:active {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -5970,56 +5970,35 @@ exports[`Storyshots Header Header itself 1`] = `
   display: flex;
   background: #fff;
   color: #333333;
-  opacity: 1;
 }
 
 .c14:hover,
 .c14 > a:hover {
   background: #f9f9f9;
   color: #333333;
-  opacity: 1;
 }
 
 .c14 > a:active {
   background: #333333;
   color: #fff;
-  opacity: 1;
 }
 
 .c14 > a.active {
   background: #fff;
-  color: #333333;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c14 > a.active:active {
   background: #fff;
-  color: #333333;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c14 > a.active:hover {
   background: #333333;
   color: #a9a9a9;
-  opacity: 1;
 }
 
 .c10 {
-  stroke: currentColor;
-  stroke-width: 0.1875rem;
-  fill: none;
-  -webkit-transform: rotate(135deg);
-  -ms-transform: rotate(135deg);
-  transform: rotate(135deg);
-  -webkit-transition: -webkit-transform 0s ease 0.1s;
-  -webkit-transition: transform 0s ease 0.1s;
-  transition: transform 0s ease 0.1s;
-  -webkit-transform: translateY(2px) rotate(-45deg);
-  -ms-transform: translateY(2px) rotate(-45deg);
-  transform: translateY(2px) rotate(-45deg);
-}
-
-.c26 {
   stroke: currentColor;
   stroke-width: 0.1875rem;
   fill: none;
@@ -6076,25 +6055,11 @@ exports[`Storyshots Header Header itself 1`] = `
 .c7 > span {
   background: #fff;
   color: #333333;
-  opacity: 1;
 }
 
 .c7 > span:hover {
   background: #f9f9f9;
   color: #333333;
-  opacity: 1;
-}
-
-.c7 > span {
-  background: #333333;
-  color: #fff;
-  opacity: 1;
-}
-
-.c7 > span:hover {
-  background: #333333;
-  color: #a9a9a9;
-  opacity: 1;
 }
 
 .c8 {
@@ -6151,8 +6116,6 @@ exports[`Storyshots Header Header itself 1`] = `
   transition: opacity 300ms ease;
   background: #f9f9f9;
   z-index: 999;
-  left: 0;
-  opacity: 1;
 }
 
 .c6 {
@@ -6579,9 +6542,12 @@ exports[`Storyshots Header Header itself 1`] = `
               className="c6"
             >
               <li
-                aria-expanded={true}
+                aria-expanded={false}
                 aria-haspopup="true"
                 className="c7"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
               >
                 <span
                   className="c8"
@@ -6613,8 +6579,8 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/engineering/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
-                      tabIndex="0"
                     >
                       Engineering
                     </a>
@@ -6626,8 +6592,8 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/design/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
-                      tabIndex="0"
                     >
                       Design
                     </a>
@@ -6639,8 +6605,8 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/training/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
-                      tabIndex="0"
                     >
                       Training
                     </a>
@@ -6655,7 +6621,6 @@ exports[`Storyshots Header Header itself 1`] = `
                   href="/our-work/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
-                  tabIndex="0"
                 >
                   Our work
                 </a>
@@ -6667,16 +6632,18 @@ exports[`Storyshots Header Header itself 1`] = `
                   className="c15"
                   href="https://medium.com/yld-engineering-blog/"
                   rel="noopener noreferrer"
-                  tabIndex="0"
                   target="_blank"
                 >
                   Blog
                 </a>
               </li>
               <li
-                aria-expanded={true}
+                aria-expanded={false}
                 aria-haspopup="true"
                 className="c7"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
               >
                 <span
                   className="c8"
@@ -6708,8 +6675,8 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/about-us/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
-                      tabIndex="0"
                     >
                       Our team
                     </a>
@@ -6721,8 +6688,8 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/contact/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
-                      tabIndex="0"
                     >
                       Contact
                     </a>
@@ -6737,7 +6704,6 @@ exports[`Storyshots Header Header itself 1`] = `
                   href="/join-us/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
-                  tabIndex="0"
                 >
                   Join us
                 </a>
@@ -6833,7 +6799,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     Services
                   </span>
                   <svg
-                    className="c26"
+                    className="c10"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -6924,7 +6890,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     About
                   </span>
                   <svg
-                    className="c26"
+                    className="c10"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -7005,38 +6971,32 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
   display: flex;
   background: #fff;
   color: #333333;
-  opacity: 1;
 }
 
 .c1:hover,
 .c1 > a:hover {
   background: #f9f9f9;
   color: #333333;
-  opacity: 1;
 }
 
 .c1 > a:active {
   background: #333333;
   color: #fff;
-  opacity: 1;
 }
 
 .c1 > a.active {
   background: #fff;
-  color: #333333;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c1 > a.active:active {
   background: #fff;
-  color: #333333;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c1 > a.active:hover {
   background: #333333;
   color: #a9a9a9;
-  opacity: 1;
 }
 
 .c0 {
@@ -7086,7 +7046,6 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
         onClick={[Function]}
         onMouseEnter={[Function]}
         style={Object {}}
-        tabIndex="0"
       >
         Here
       </a>
@@ -7099,7 +7058,6 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
         href="/there"
         onClick={[Function]}
         onMouseEnter={[Function]}
-        tabIndex="0"
       >
         There
       </a>
@@ -7112,7 +7070,6 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
         href="/https:/uk.linkedin.com/"
         onClick={[Function]}
         onMouseEnter={[Function]}
-        tabIndex="0"
       >
         LinkedIn (external anchor)
       </a>
@@ -7150,38 +7107,32 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   display: flex;
   background: #fff;
   color: #333333;
-  opacity: 1;
 }
 
 .c8:hover,
 .c8 > a:hover {
   background: #f9f9f9;
   color: #333333;
-  opacity: 1;
 }
 
 .c8 > a:active {
   background: #333333;
   color: #fff;
-  opacity: 1;
 }
 
 .c8 > a.active {
   background: #fff;
-  color: #333333;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c8 > a.active:active {
   background: #fff;
-  color: #333333;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c8 > a.active:hover {
   background: #333333;
   color: #a9a9a9;
-  opacity: 1;
 }
 
 .c4 {
@@ -7194,9 +7145,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   -webkit-transition: -webkit-transform 0s ease 0.1s;
   -webkit-transition: transform 0s ease 0.1s;
   transition: transform 0s ease 0.1s;
-  -webkit-transform: translateY(2px) rotate(-45deg);
-  -ms-transform: translateY(2px) rotate(-45deg);
-  transform: translateY(2px) rotate(-45deg);
 }
 
 .c6 {
@@ -7244,25 +7192,11 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 .c1 > span {
   background: #fff;
   color: #333333;
-  opacity: 1;
 }
 
 .c1 > span:hover {
   background: #f9f9f9;
   color: #333333;
-  opacity: 1;
-}
-
-.c1 > span {
-  background: #333333;
-  color: #fff;
-  opacity: 1;
-}
-
-.c1 > span:hover {
-  background: #333333;
-  color: #a9a9a9;
-  opacity: 1;
 }
 
 .c2 {
@@ -7319,8 +7253,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   transition: opacity 300ms ease;
   background: #f9f9f9;
   z-index: 999;
-  left: 0;
-  opacity: 1;
 }
 
 .c0 {
@@ -7361,9 +7293,12 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
     className="c0"
   >
     <li
-      aria-expanded={true}
+      aria-expanded={false}
       aria-haspopup="true"
       className="c1"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
     >
       <span
         className="c2"
@@ -7395,8 +7330,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/item-1/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
-            tabIndex="0"
           >
             Item 1
           </a>
@@ -7408,8 +7343,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/item-2/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
-            tabIndex="0"
           >
             Item 2
           </a>
@@ -7421,8 +7356,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/item-3/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
-            tabIndex="0"
           >
             Item 3
           </a>
@@ -7437,7 +7372,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
         href="/anchor/"
         onClick={[Function]}
         onMouseEnter={[Function]}
-        tabIndex="0"
       >
         First anchor
       </a>
@@ -7449,16 +7383,18 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
         className="c9"
         href="https://uk.linkedin.com/"
         rel="noopener noreferrer"
-        tabIndex="0"
         target="_blank"
       >
         LinkedIn (external anchor)
       </a>
     </li>
     <li
-      aria-expanded={true}
+      aria-expanded={false}
       aria-haspopup="true"
       className="c1"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
     >
       <span
         className="c2"
@@ -7490,8 +7426,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/go-here/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
-            tabIndex="0"
           >
             Go here
           </a>
@@ -7503,8 +7439,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/go-there/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
-            tabIndex="0"
           >
             Go there
           </a>
@@ -7519,7 +7455,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
         href="/last-anchor/"
         onClick={[Function]}
         onMouseEnter={[Function]}
-        tabIndex="0"
       >
         Last anchor
       </a>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -2254,6 +2254,8 @@ exports[`Storyshots CaseStudy CaseStudyPreview 1`] = `
   display: inline-block;
   -webkit-transition: all 200ms ease-out;
   transition: all 200ms ease-out;
+  -webkit-transition-property: background,color;
+  transition-property: background,color;
 }
 
 .c14:after {
@@ -4630,6 +4632,8 @@ exports[`Storyshots GetInTouch GetInTouch 1`] = `
   display: inline-block;
   -webkit-transition: all 200ms ease-out;
   transition: all 200ms ease-out;
+  -webkit-transition-property: background,color;
+  transition-property: background,color;
 }
 
 .c8:after {
@@ -5922,10 +5926,12 @@ exports[`Storyshots Header Header itself 1`] = `
   width: 5rem;
   height: 5rem;
   margin: 0.25rem -1.25rem 0.25rem 0.25rem;
+  outline: 0.25rem solid transparent;
 }
 
 .c16:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c16:active {
@@ -5937,22 +5943,23 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 .c15 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
 }
 
-.c15:focus:focus {
-  outline: 0.25rem solid #65FFCD;
+.c15:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
-.c15:focus:active {
+.c15:active {
   outline: none;
 }
 
@@ -5964,14 +5971,6 @@ exports[`Storyshots Header Header itself 1`] = `
   background: #fff;
   color: #333333;
   opacity: 1;
-}
-
-.c14:focus:focus {
-  outline: 0.25rem solid #65FFCD;
-}
-
-.c14:focus:active {
-  outline: none;
 }
 
 .c14:hover,
@@ -6015,6 +6014,21 @@ exports[`Storyshots Header Header itself 1`] = `
   -webkit-transition: -webkit-transform 0s ease 0.1s;
   -webkit-transition: transform 0s ease 0.1s;
   transition: transform 0s ease 0.1s;
+  -webkit-transform: translateY(2px) rotate(-45deg);
+  -ms-transform: translateY(2px) rotate(-45deg);
+  transform: translateY(2px) rotate(-45deg);
+}
+
+.c26 {
+  stroke: currentColor;
+  stroke-width: 0.1875rem;
+  fill: none;
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+  -webkit-transition: -webkit-transform 0s ease 0.1s;
+  -webkit-transition: transform 0s ease 0.1s;
+  transition: transform 0s ease 0.1s;
 }
 
 .c12 {
@@ -6024,34 +6038,33 @@ exports[`Storyshots Header Header itself 1`] = `
   display: flex;
 }
 
-.c12 > a:focus:focus {
-  outline: 0.25rem solid #65FFCD;
-}
-
-.c12 > a:focus:active {
-  outline: none;
-}
-
 .c13 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
   width: 100%;
   background: #f9f9f9;
   color: #333333;
-  opacity: 0.5;
+}
+
+.c13:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c13:active {
+  outline: none;
 }
 
 .c13:hover,
 .c13.active {
   color: #333333;
-  opacity: 1;
 }
 
 .c7 {
@@ -6072,6 +6085,18 @@ exports[`Storyshots Header Header itself 1`] = `
   opacity: 1;
 }
 
+.c7 > span {
+  background: #333333;
+  color: #fff;
+  opacity: 1;
+}
+
+.c7 > span:hover {
+  background: #333333;
+  color: #a9a9a9;
+  opacity: 1;
+}
+
 .c8 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -6084,19 +6109,20 @@ exports[`Storyshots Header Header itself 1`] = `
   -webkit-transition: outline 300ms ease-out;
   transition: outline 300ms ease-out;
   z-index: 2;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
 }
 
 .c8:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c8:active {
@@ -6125,6 +6151,8 @@ exports[`Storyshots Header Header itself 1`] = `
   transition: opacity 300ms ease;
   background: #f9f9f9;
   z-index: 999;
+  left: 0;
+  opacity: 1;
 }
 
 .c6 {
@@ -6152,10 +6180,12 @@ exports[`Storyshots Header Header itself 1`] = `
   width: 5rem;
   height: 5rem;
   margin: 0.25rem;
+  outline: 0.25rem solid transparent;
 }
 
 .c21:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c21:active {
@@ -6172,8 +6202,8 @@ exports[`Storyshots Header Header itself 1`] = `
   -ms-flex-align: center;
   align-items: center;
   cursor: pointer;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
@@ -6181,12 +6211,14 @@ exports[`Storyshots Header Header itself 1`] = `
   line-height: 1.5rem;
   padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
   margin: 0.25rem;
+  outline: 0.25rem solid transparent;
   color: #fff;
   opacity: 0.5;
 }
 
 .c24:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c24:active {
@@ -6202,8 +6234,8 @@ exports[`Storyshots Header Header itself 1`] = `
 
 .c23 {
   display: block;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
@@ -6225,10 +6257,12 @@ exports[`Storyshots Header Header itself 1`] = `
 .c23:focus {
   color: #fff;
   opacity: 1;
+  outline: 0.25rem solid transparent;
 }
 
 .c23:focus:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c23:focus:active {
@@ -6284,8 +6318,13 @@ exports[`Storyshots Header Header itself 1`] = `
   height: 84px;
 }
 
+.c5 {
+  outline: 0.25rem solid transparent;
+}
+
 .c5:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c5:active {
@@ -6540,12 +6579,9 @@ exports[`Storyshots Header Header itself 1`] = `
               className="c6"
             >
               <li
-                aria-expanded={false}
+                aria-expanded={true}
                 aria-haspopup="true"
                 className="c7"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
               >
                 <span
                   className="c8"
@@ -6578,6 +6614,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       href="/engineering/"
                       onClick={[Function]}
                       onMouseEnter={[Function]}
+                      tabIndex="0"
                     >
                       Engineering
                     </a>
@@ -6590,6 +6627,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       href="/design/"
                       onClick={[Function]}
                       onMouseEnter={[Function]}
+                      tabIndex="0"
                     >
                       Design
                     </a>
@@ -6602,6 +6640,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       href="/training/"
                       onClick={[Function]}
                       onMouseEnter={[Function]}
+                      tabIndex="0"
                     >
                       Training
                     </a>
@@ -6616,6 +6655,7 @@ exports[`Storyshots Header Header itself 1`] = `
                   href="/our-work/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
+                  tabIndex="0"
                 >
                   Our work
                 </a>
@@ -6627,18 +6667,16 @@ exports[`Storyshots Header Header itself 1`] = `
                   className="c15"
                   href="https://medium.com/yld-engineering-blog/"
                   rel="noopener noreferrer"
+                  tabIndex="0"
                   target="_blank"
                 >
                   Blog
                 </a>
               </li>
               <li
-                aria-expanded={false}
+                aria-expanded={true}
                 aria-haspopup="true"
                 className="c7"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
               >
                 <span
                   className="c8"
@@ -6671,6 +6709,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       href="/about-us/"
                       onClick={[Function]}
                       onMouseEnter={[Function]}
+                      tabIndex="0"
                     >
                       Our team
                     </a>
@@ -6683,6 +6722,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       href="/contact/"
                       onClick={[Function]}
                       onMouseEnter={[Function]}
+                      tabIndex="0"
                     >
                       Contact
                     </a>
@@ -6697,6 +6737,7 @@ exports[`Storyshots Header Header itself 1`] = `
                   href="/join-us/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
+                  tabIndex="0"
                 >
                   Join us
                 </a>
@@ -6792,7 +6833,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     Services
                   </span>
                   <svg
-                    className="c10"
+                    className="c26"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -6883,7 +6924,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     About
                   </span>
                   <svg
-                    className="c10"
+                    className="c26"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -6937,22 +6978,23 @@ exports[`Storyshots Header Header itself 1`] = `
 
 exports[`Storyshots Header TopNavbar - light theme 1`] = `
 .c2 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
 }
 
-.c2:focus:focus {
-  outline: 0.25rem solid #65FFCD;
+.c2:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
-.c2:focus:active {
+.c2:active {
   outline: none;
 }
 
@@ -6964,14 +7006,6 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
   background: #fff;
   color: #333333;
   opacity: 1;
-}
-
-.c1:focus:focus {
-  outline: 0.25rem solid #65FFCD;
-}
-
-.c1:focus:active {
-  outline: none;
 }
 
 .c1:hover,
@@ -7052,6 +7086,7 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
         onClick={[Function]}
         onMouseEnter={[Function]}
         style={Object {}}
+        tabIndex="0"
       >
         Here
       </a>
@@ -7064,6 +7099,7 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
         href="/there"
         onClick={[Function]}
         onMouseEnter={[Function]}
+        tabIndex="0"
       >
         There
       </a>
@@ -7076,6 +7112,7 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
         href="/https:/uk.linkedin.com/"
         onClick={[Function]}
         onMouseEnter={[Function]}
+        tabIndex="0"
       >
         LinkedIn (external anchor)
       </a>
@@ -7086,22 +7123,23 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
 
 exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 .c9 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
 }
 
-.c9:focus:focus {
-  outline: 0.25rem solid #65FFCD;
+.c9:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
-.c9:focus:active {
+.c9:active {
   outline: none;
 }
 
@@ -7113,14 +7151,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   background: #fff;
   color: #333333;
   opacity: 1;
-}
-
-.c8:focus:focus {
-  outline: 0.25rem solid #65FFCD;
-}
-
-.c8:focus:active {
-  outline: none;
 }
 
 .c8:hover,
@@ -7164,6 +7194,9 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   -webkit-transition: -webkit-transform 0s ease 0.1s;
   -webkit-transition: transform 0s ease 0.1s;
   transition: transform 0s ease 0.1s;
+  -webkit-transform: translateY(2px) rotate(-45deg);
+  -ms-transform: translateY(2px) rotate(-45deg);
+  transform: translateY(2px) rotate(-45deg);
 }
 
 .c6 {
@@ -7173,34 +7206,33 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   display: flex;
 }
 
-.c6 > a:focus:focus {
-  outline: 0.25rem solid #65FFCD;
-}
-
-.c6 > a:focus:active {
-  outline: none;
-}
-
 .c7 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
   width: 100%;
   background: #f9f9f9;
   color: #333333;
-  opacity: 0.5;
+}
+
+.c7:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c7:active {
+  outline: none;
 }
 
 .c7:hover,
 .c7.active {
   color: #333333;
-  opacity: 1;
 }
 
 .c1 {
@@ -7221,6 +7253,18 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   opacity: 1;
 }
 
+.c1 > span {
+  background: #333333;
+  color: #fff;
+  opacity: 1;
+}
+
+.c1 > span:hover {
+  background: #333333;
+  color: #a9a9a9;
+  opacity: 1;
+}
+
 .c2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -7233,19 +7277,20 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   -webkit-transition: outline 300ms ease-out;
   transition: outline 300ms ease-out;
   z-index: 2;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out, outline 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
   outline: none;
   font-weight: 400;
   font-size: 1.0625rem;
   line-height: 1.5rem;
-  padding: 0.375rem 0.6875rem 0.625rem;
-  margin: 0.25rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
 }
 
 .c2:focus {
-  outline: 0.25rem solid #65FFCD;
+  outline-color: #65FFCD;
+  z-index: 1;
 }
 
 .c2:active {
@@ -7274,6 +7319,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   transition: opacity 300ms ease;
   background: #f9f9f9;
   z-index: 999;
+  left: 0;
+  opacity: 1;
 }
 
 .c0 {
@@ -7314,12 +7361,9 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
     className="c0"
   >
     <li
-      aria-expanded={false}
+      aria-expanded={true}
       aria-haspopup="true"
       className="c1"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
     >
       <span
         className="c2"
@@ -7352,6 +7396,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             href="/item-1/"
             onClick={[Function]}
             onMouseEnter={[Function]}
+            tabIndex="0"
           >
             Item 1
           </a>
@@ -7364,6 +7409,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             href="/item-2/"
             onClick={[Function]}
             onMouseEnter={[Function]}
+            tabIndex="0"
           >
             Item 2
           </a>
@@ -7376,6 +7422,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             href="/item-3/"
             onClick={[Function]}
             onMouseEnter={[Function]}
+            tabIndex="0"
           >
             Item 3
           </a>
@@ -7390,6 +7437,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
         href="/anchor/"
         onClick={[Function]}
         onMouseEnter={[Function]}
+        tabIndex="0"
       >
         First anchor
       </a>
@@ -7401,18 +7449,16 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
         className="c9"
         href="https://uk.linkedin.com/"
         rel="noopener noreferrer"
+        tabIndex="0"
         target="_blank"
       >
         LinkedIn (external anchor)
       </a>
     </li>
     <li
-      aria-expanded={false}
+      aria-expanded={true}
       aria-haspopup="true"
       className="c1"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
     >
       <span
         className="c2"
@@ -7445,6 +7491,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             href="/go-here/"
             onClick={[Function]}
             onMouseEnter={[Function]}
+            tabIndex="0"
           >
             Go here
           </a>
@@ -7457,6 +7504,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             href="/go-there/"
             onClick={[Function]}
             onMouseEnter={[Function]}
+            tabIndex="0"
           >
             Go there
           </a>
@@ -7471,6 +7519,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
         href="/last-anchor/"
         onClick={[Function]}
         onMouseEnter={[Function]}
+        tabIndex="0"
       >
         Last anchor
       </a>
@@ -9191,6 +9240,8 @@ exports[`Storyshots Statement Statement Rich Text 1`] = `
   display: inline-block;
   -webkit-transition: all 200ms ease-out;
   transition: all 200ms ease-out;
+  -webkit-transition-property: background,color;
+  transition-property: background,color;
 }
 
 .c6:after {
@@ -12227,6 +12278,8 @@ exports[`Storyshots Title and List with extra content 1`] = `
   display: inline-block;
   -webkit-transition: all 200ms ease-out;
   transition: all 200ms ease-out;
+  -webkit-transition-property: background,color;
+  transition-property: background,color;
 }
 
 .c8:after {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6029,7 +6029,7 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
   width: 100%;
   background: #f9f9f9;
-  color: #333333;
+  color: #828282;
 }
 
 .c13:focus {
@@ -6175,8 +6175,7 @@ exports[`Storyshots Header Header itself 1`] = `
   padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
   margin: 0.25rem;
   outline: 0.25rem solid transparent;
-  color: #fff;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c24:focus {
@@ -6186,6 +6185,11 @@ exports[`Storyshots Header Header itself 1`] = `
 
 .c24:active {
   outline: none;
+}
+
+.c24:hover,
+.c24:focus {
+  color: #fff;
 }
 
 .c25 {
@@ -6206,20 +6210,17 @@ exports[`Storyshots Header Header itself 1`] = `
   line-height: 1.5rem;
   padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
   margin: 0.25rem;
-  color: #fff;
-  opacity: 0.5;
+  color: #828282;
 }
 
 .c23:hover,
 .c23:active,
 .c23.active {
   color: #fff;
-  opacity: 1;
 }
 
 .c23:focus {
   color: #fff;
-  opacity: 1;
   outline: 0.25rem solid transparent;
 }
 
@@ -6777,7 +6778,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 0.5;
 ",
                       ],
                       "hoverActive": Array [
@@ -6785,7 +6785,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 1;
 ",
                       ],
                     }
@@ -6837,7 +6836,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 0.5;
 ",
                       ],
                       "hoverActive": Array [
@@ -6845,7 +6843,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 1;
 ",
                       ],
                     }
@@ -6868,7 +6865,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 0.5;
 ",
                       ],
                       "hoverActive": Array [
@@ -6876,7 +6872,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 1;
 ",
                       ],
                     }
@@ -6928,7 +6923,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 0.5;
 ",
                       ],
                       "hoverActive": Array [
@@ -6936,7 +6930,6 @@ exports[`Storyshots Header Header itself 1`] = `
   color: ",
                         [Function],
                         ";
-  opacity: 1;
 ",
                       ],
                     }
@@ -7180,7 +7173,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   outline: 0.25rem solid transparent;
   width: 100%;
   background: #f9f9f9;
-  color: #333333;
+  color: #828282;
 }
 
 .c7:focus {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6450,6 +6450,26 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
+  .c14 {
+    margin-right: 0.375rem;
+  }
+
+  .c14:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c7 {
+    margin-right: 0.375rem;
+  }
+
+  .c7:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
   .c6 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -6466,14 +6486,6 @@ exports[`Storyshots Header Header itself 1`] = `
     -ms-flex: 1;
     flex: 1;
     padding: 1.25rem 0rem 1rem;
-    padding-right: 0rem;
-  }
-
-  .c6 > li {
-    padding-right: 0.375rem;
-  }
-
-  .c6 > li:last-child {
     padding-right: 0rem;
   }
 }
@@ -7004,6 +7016,16 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
 }
 
 @media screen and (min-width:960px) {
+  .c1 {
+    margin-right: 0.375rem;
+  }
+
+  .c1:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -7020,14 +7042,6 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
     -ms-flex: 1;
     flex: 1;
     padding: 1.25rem 0rem 1rem;
-    padding-right: 0rem;
-  }
-
-  .c0 > li {
-    padding-right: 0.375rem;
-  }
-
-  .c0 > li:last-child {
     padding-right: 0rem;
   }
 }
@@ -7260,6 +7274,26 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 }
 
 @media screen and (min-width:960px) {
+  .c8 {
+    margin-right: 0.375rem;
+  }
+
+  .c8:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c1 {
+    margin-right: 0.375rem;
+  }
+
+  .c1:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
   .c0 {
     display: -webkit-box;
     display: -webkit-flex;
@@ -7276,14 +7310,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
     -ms-flex: 1;
     flex: 1;
     padding: 1.25rem 0rem 1rem;
-    padding-right: 0rem;
-  }
-
-  .c0 > li {
-    padding-right: 0.375rem;
-  }
-
-  .c0 > li:last-child {
     padding-right: 0rem;
   }
 }


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/Yltvi4x3)

- The main issue of this ticket was due to a conflict between the `onMouseDown` and `onFocus` callbacks, which were affecting the same state. That was fixed.

Besides that, I improved some other scenarios:
- On Safari, there were some problems when trying to navigate by tabbing on the keyboard. This  was due to it not being able to transition the outline property. So in fact, the items were being focused, just the outline was not displaying corrrectly. Given that,  I've removed the outline transition.
- Also, I noticed that the `opacity: 0.5` rules were affecting the outline as well. Since it's not a good practice to reduce the opacity of the whole element just to get a lighter shade of the text color, I changed those rules to just use the lighter version of the text color (instead of fading out the whole component)
- Given some comments from the designers, the outline wasn't supposed to show up when clicking the dropdowns, just when navigating with the keyboard, so I added a state property to control that style.
- Finally, noticed some spacing issues on the topnav items, so I fixed that as well.

Note: It seems that navigating with the keyboard on MacOS is not so straight forward. For it to work well on Firefox, the options represented on my screenshot has to be activated. On Chrome, everything works out of the box. On Safari, however, a special option needs to be set. This only seems to happen if the user doesn't have voice-over active. More on that [here](http://www.weba11y.com/blog/2014/07/07/keyboard-navigation-in-mac-browsers/)


![image](https://user-images.githubusercontent.com/3236388/54842752-ae20ca00-4cca-11e9-8bb2-4af255de57f1.png)

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
