### PR TITLE
fix: Service pages to allow templated and non templated case studies

### DIFF
--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -101,7 +101,7 @@ const Service = ({ data: { contentfulService: service }, location }) => {
           </Grid>
         </Padding>
       </GreyBackground>
-      <CaseStudyPreview isTop={false} caseStudy={service.bottomCaseStudy} />
+      <CaseStudyPreview isTop={false} caseStudy={service.relatedCaseStudy[0]} />
     </Layout>
   )
 }
@@ -118,20 +118,39 @@ export const pageQuery = graphql`
       mainPageIntroSentence {
         mainPageIntroSentence
       }
-      bottomCaseStudy {
-        title
-        slug
-        introSentence
-        posterImage {
+      relatedCaseStudy {
+        ... on ContentfulTemplatedCaseStudy {
           title
-          fluid(maxWidth: 600) {
-            ...GatsbyContentfulFluid_withWebp
+          slug
+          introSentence
+          posterImage {
+            title
+            fluid(maxWidth: 600) {
+              ...GatsbyContentfulFluid_withWebp
+            }
+            file {
+              url
+            }
           }
-          file {
-            url
-          }
+          posterColor
         }
-        posterColor
+        ... on ContentfulNonTemplatedCaseStudy {
+          title
+          slug
+          intro: introSentence {
+            introSentence
+          }
+          posterImage {
+            title
+            fluid(maxWidth: 600) {
+              ...GatsbyContentfulFluid_withWebp
+            }
+            file {
+              url
+            }
+          }
+          posterColor
+        }
       }
       caseStudies {
         ... on ContentfulTemplatedCaseStudy {


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/2qjcGlV1)

Using new field from contentful, that allows both templated and non templated case studies to be used on the engineering and design service pages
## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
