### PR TITLE
Navbar tweaks - change navbar item states' font colour & weight

### DIFF
--- a/src/components/Header/SideNav/outerItemStates.js
+++ b/src/components/Header/SideNav/outerItemStates.js
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 
 const defaultStyles = css`
-  color: ${props => props.theme.colors.textLight};
+  color: #858196;
 `
 
 const hoverActiveStyles = css`

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -25,10 +25,10 @@ const DropdownContainer = styled(TopNavItem)`
 
   ${is('expanded')`
     > span {
-      ${props => props.states.hover}
+      ${props => props.states.clickTap}
 
       &:hover {
-        ${props => props.states.activeAndHover}
+        ${props => props.states.hover}
       }
     }
   `}

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -25,7 +25,7 @@ const DropdownContainer = styled(TopNavItem)`
 
   ${is('expanded')`
     > span {
-      ${props => props.states.clickTap}
+      ${props => props.states.hover}
 
       &:hover {
         ${props => props.states.activeAndHover}

--- a/src/components/Header/TopNav/outerItemStates.js
+++ b/src/components/Header/TopNav/outerItemStates.js
@@ -18,13 +18,11 @@ const clickTapLight = css`
 const activeLight = css`
   background: ${props => props.theme.colors.white};
   color: ${props => props.theme.colors.text};
-  font-weight: bold;
 `
 
 const activeAndHoverLight = css`
   background: ${props => props.theme.colors.greyBG};
   color: ${props => props.theme.colors.text};
-  font-weight: bold;
 `
 
 const defaultDark = css`
@@ -45,13 +43,11 @@ const clickTapDark = css`
 const activeDark = css`
   background: ${props => props.theme.colors.blueBg};
   color: ${props => props.theme.colors.white};
-  font-weight: bold;
 `
 
 const activeAndHoverDark = css`
   background: #3a3553;
   color: ${props => props.theme.colors.white};
-  font-weight: bold;
 `
 
 export const lightStates = {

--- a/src/components/Header/TopNav/outerItemStates.js
+++ b/src/components/Header/TopNav/outerItemStates.js
@@ -17,12 +17,14 @@ const clickTapLight = css`
 
 const activeLight = css`
   background: ${props => props.theme.colors.white};
-  color: ${props => props.theme.colors.textLight};
+  color: ${props => props.theme.colors.text};
+  font-weight: bold;
 `
 
 const activeAndHoverLight = css`
   background: ${props => props.theme.colors.greyBG};
   color: ${props => props.theme.colors.text};
+  font-weight: bold;
 `
 
 const defaultDark = css`
@@ -42,12 +44,14 @@ const clickTapDark = css`
 
 const activeDark = css`
   background: ${props => props.theme.colors.blueBg};
-  color: ${props => props.theme.colors.textLight};
+  color: ${props => props.theme.colors.white};
+  font-weight: bold;
 `
 
 const activeAndHoverDark = css`
   background: #3a3553;
   color: ${props => props.theme.colors.white};
+  font-weight: bold;
 `
 
 export const lightStates = {

--- a/src/components/Header/TopNav/outerItemStates.js
+++ b/src/components/Header/TopNav/outerItemStates.js
@@ -6,8 +6,8 @@ const defaultLight = css`
 `
 
 const hoverLight = css`
-  background: ${props => props.theme.colors.greyBG};
-  color: ${props => props.theme.colors.text};
+  background: ${props => props.theme.colors.text};
+  color: #a9a9a9;
 `
 
 const clickTapLight = css`
@@ -21,8 +21,8 @@ const activeLight = css`
 `
 
 const activeAndHoverLight = css`
-  background: ${props => props.theme.colors.text};
-  color: #a9a9a9;
+  background: ${props => props.theme.colors.greyBG};
+  color: ${props => props.theme.colors.text};
 `
 
 const defaultDark = css`
@@ -31,8 +31,8 @@ const defaultDark = css`
 `
 
 const hoverDark = css`
-  background: #3a3553;
-  color: ${props => props.theme.colors.white};
+  background: ${props => props.theme.colors.vibrant};
+  color: #007f56;
 `
 
 const clickTapDark = css`
@@ -46,8 +46,8 @@ const activeDark = css`
 `
 
 const activeAndHoverDark = css`
-  background: ${props => props.theme.colors.vibrant};
-  color: #007f56;
+  background: #3a3553;
+  color: ${props => props.theme.colors.white};
 `
 
 export const lightStates = {

--- a/src/components/Header/TopNav/outerItemStates.js
+++ b/src/components/Header/TopNav/outerItemStates.js
@@ -17,7 +17,7 @@ const clickTapLight = css`
 
 const activeLight = css`
   background: ${props => props.theme.colors.white};
-  color: ${props => props.theme.colors.text};
+  color: ${props => props.theme.colors.textLight};
 `
 
 const activeAndHoverLight = css`
@@ -42,7 +42,7 @@ const clickTapDark = css`
 
 const activeDark = css`
   background: ${props => props.theme.colors.blueBg};
-  color: ${props => props.theme.colors.white};
+  color: ${props => props.theme.colors.textLight};
 `
 
 const activeAndHoverDark = css`

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -5985,12 +5985,12 @@ exports[`Storyshots Header Header itself 1`] = `
 
 .c14 > a.active {
   background: #fff;
-  color: #333333;
+  color: #828282;
 }
 
 .c14 > a.active:active {
   background: #fff;
-  color: #333333;
+  color: #828282;
 }
 
 .c14 > a.active:hover {
@@ -6986,12 +6986,12 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
 
 .c1 > a.active {
   background: #fff;
-  color: #333333;
+  color: #828282;
 }
 
 .c1 > a.active:active {
   background: #fff;
-  color: #333333;
+  color: #828282;
 }
 
 .c1 > a.active:hover {
@@ -7124,12 +7124,12 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 
 .c8 > a.active {
   background: #fff;
-  color: #333333;
+  color: #828282;
 }
 
 .c8 > a.active:active {
   background: #fff;
-  color: #333333;
+  color: #828282;
 }
 
 .c8 > a.active:hover {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -5986,19 +5986,16 @@ exports[`Storyshots Header Header itself 1`] = `
 .c14 > a.active {
   background: #fff;
   color: #333333;
-  font-weight: bold;
 }
 
 .c14 > a.active:active {
   background: #fff;
   color: #333333;
-  font-weight: bold;
 }
 
 .c14 > a.active:hover {
   background: #f9f9f9;
   color: #333333;
-  font-weight: bold;
 }
 
 .c10 {
@@ -6990,19 +6987,16 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
 .c1 > a.active {
   background: #fff;
   color: #333333;
-  font-weight: bold;
 }
 
 .c1 > a.active:active {
   background: #fff;
   color: #333333;
-  font-weight: bold;
 }
 
 .c1 > a.active:hover {
   background: #f9f9f9;
   color: #333333;
-  font-weight: bold;
 }
 
 .c0 {
@@ -7131,19 +7125,16 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 .c8 > a.active {
   background: #fff;
   color: #333333;
-  font-weight: bold;
 }
 
 .c8 > a.active:active {
   background: #fff;
   color: #333333;
-  font-weight: bold;
 }
 
 .c8 > a.active:hover {
   background: #f9f9f9;
   color: #333333;
-  font-weight: bold;
 }
 
 .c4 {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -5974,8 +5974,8 @@ exports[`Storyshots Header Header itself 1`] = `
 
 .c14:hover,
 .c14 > a:hover {
-  background: #f9f9f9;
-  color: #333333;
+  background: #333333;
+  color: #a9a9a9;
 }
 
 .c14 > a:active {
@@ -5985,17 +5985,20 @@ exports[`Storyshots Header Header itself 1`] = `
 
 .c14 > a.active {
   background: #fff;
-  color: #828282;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c14 > a.active:active {
   background: #fff;
-  color: #828282;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c14 > a.active:hover {
-  background: #333333;
-  color: #a9a9a9;
+  background: #f9f9f9;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c10 {
@@ -6058,8 +6061,8 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 .c7 > span:hover {
-  background: #f9f9f9;
-  color: #333333;
+  background: #333333;
+  color: #a9a9a9;
 }
 
 .c8 {
@@ -6975,8 +6978,8 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
 
 .c1:hover,
 .c1 > a:hover {
-  background: #f9f9f9;
-  color: #333333;
+  background: #333333;
+  color: #a9a9a9;
 }
 
 .c1 > a:active {
@@ -6986,17 +6989,20 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
 
 .c1 > a.active {
   background: #fff;
-  color: #828282;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c1 > a.active:active {
   background: #fff;
-  color: #828282;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c1 > a.active:hover {
-  background: #333333;
-  color: #a9a9a9;
+  background: #f9f9f9;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c0 {
@@ -7113,8 +7119,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 
 .c8:hover,
 .c8 > a:hover {
-  background: #f9f9f9;
-  color: #333333;
+  background: #333333;
+  color: #a9a9a9;
 }
 
 .c8 > a:active {
@@ -7124,17 +7130,20 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 
 .c8 > a.active {
   background: #fff;
-  color: #828282;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c8 > a.active:active {
   background: #fff;
-  color: #828282;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c8 > a.active:hover {
-  background: #333333;
-  color: #a9a9a9;
+  background: #f9f9f9;
+  color: #333333;
+  font-weight: bold;
 }
 
 .c4 {
@@ -7197,8 +7206,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 }
 
 .c1 > span:hover {
-  background: #f9f9f9;
-  color: #333333;
+  background: #333333;
+  color: #a9a9a9;
 }
 
 .c2 {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6175,7 +6175,7 @@ exports[`Storyshots Header Header itself 1`] = `
   padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
   margin: 0.25rem;
   outline: 0.25rem solid transparent;
-  color: #828282;
+  color: #858196;
 }
 
 .c24:focus {
@@ -6210,7 +6210,7 @@ exports[`Storyshots Header Header itself 1`] = `
   line-height: 1.5rem;
   padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
   margin: 0.25rem;
-  color: #828282;
+  color: #858196;
 }
 
 .c23:hover,
@@ -6770,9 +6770,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     Object {
                       "default": Array [
                         "
-  color: ",
-                        [Function],
-                        ";
+  color: #858196;
 ",
                       ],
                       "hoverActive": Array [
@@ -6828,9 +6826,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     Object {
                       "default": Array [
                         "
-  color: ",
-                        [Function],
-                        ";
+  color: #858196;
 ",
                       ],
                       "hoverActive": Array [
@@ -6857,9 +6853,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     Object {
                       "default": Array [
                         "
-  color: ",
-                        [Function],
-                        ";
+  color: #858196;
 ",
                       ],
                       "hoverActive": Array [
@@ -6915,9 +6909,7 @@ exports[`Storyshots Header Header itself 1`] = `
                     Object {
                       "default": Array [
                         "
-  color: ",
-                        [Function],
-                        ";
+  color: #858196;
 ",
                       ],
                       "hoverActive": Array [


### PR DESCRIPTION
## Top nav tweaks (2, 3 & 4) - [Trello ticket](https://trello.com/c/askfIg4a/448-top-nav-tweaks)

- switch styles for `hover` & `hoverAndActive` states (on both light and dark theme)
- change the styles that we use for "expanded" state of dropdown select button - now based on "hover" rather than "clickTap", so that it looks the same as the anchors next to it
- add bold font weight to active & active+hover

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
