### PR TITLE
fix bug: Dropdown links not navigating on safari

### DIFF
--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -105,6 +105,11 @@ export default class Dropdown extends PureComponent {
     this.setState({ clicked: true, isExpanded: !this.state.isExpanded })
   }
 
+  handleItemClick = e => {
+    e.preventDefault()
+    this.setState({ clicked: false })
+  }
+
   handleFocus = () => {
     if (this.hasTouch()) {
       return
@@ -155,6 +160,7 @@ export default class Dropdown extends PureComponent {
               href={href}
               to={to}
               activeClassName="active"
+              onMouseDown={this.handleItemClick}
             >
               {label}
             </InnerAnchorItem>

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -105,7 +105,7 @@ export default class Dropdown extends PureComponent {
     this.setState({ clicked: true, isExpanded: !this.state.isExpanded })
   }
 
-  handleItemClick = e => {
+  handleItemMouseDown = e => {
     e.preventDefault()
     e.stopPropagation()
     this.setState({ clicked: false })
@@ -161,7 +161,7 @@ export default class Dropdown extends PureComponent {
               href={href}
               to={to}
               activeClassName="active"
-              onMouseDown={this.handleItemClick}
+              onMouseDown={this.handleItemMouseDown}
             >
               {label}
             </InnerAnchorItem>

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -107,6 +107,7 @@ export default class Dropdown extends PureComponent {
 
   handleItemClick = e => {
     e.preventDefault()
+    e.stopPropagation()
     this.setState({ clicked: false })
   }
 

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -95,7 +95,7 @@ export default class Dropdown extends PureComponent {
     if (this.hasTouch()) {
       return
     }
-    this.setState({ clicked: true, isExpanded: !this.state.isExpanded })
+    this.setState({ clicked: true })
   }
 
   handleClick = () => {
@@ -122,7 +122,7 @@ export default class Dropdown extends PureComponent {
     if (this.hasTouch()) {
       return
     }
-    this.setState({ isExpanded: false })
+    this.setState({ clicked: false, isExpanded: false })
   }
 
   hasTouch = () => {

--- a/src/components/Header/TopNav/InnerAnchorItem.js
+++ b/src/components/Header/TopNav/InnerAnchorItem.js
@@ -31,10 +31,16 @@ export const InnerAnchorItem = ({
   href,
   activeClassName,
   themeVariation,
+  onMouseDown,
   ...props
 }) => (
   <InnerListItem themeVariation={themeVariation} {...props}>
-    <InnerAnchor href={href} to={to} activeClassName={activeClassName}>
+    <InnerAnchor
+      href={href}
+      to={to}
+      activeClassName={activeClassName}
+      onMouseDown={onMouseDown}
+    >
       {children}
     </InnerAnchor>
   </InnerListItem>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6596,6 +6596,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/engineering/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                     >
                       Engineering
@@ -6608,6 +6609,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/design/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                     >
                       Design
@@ -6620,6 +6622,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/training/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                     >
                       Training
@@ -6690,6 +6693,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/about-us/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                     >
                       Our team
@@ -6702,6 +6706,7 @@ exports[`Storyshots Header Header itself 1`] = `
                       className="c13"
                       href="/contact/"
                       onClick={[Function]}
+                      onMouseDown={[Function]}
                       onMouseEnter={[Function]}
                     >
                       Contact
@@ -7354,6 +7359,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/item-1/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
           >
             Item 1
@@ -7366,6 +7372,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/item-2/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
           >
             Item 2
@@ -7378,6 +7385,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/item-3/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
           >
             Item 3
@@ -7448,6 +7456,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/go-here/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
           >
             Go here
@@ -7460,6 +7469,7 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
             className="c7"
             href="/go-there/"
             onClick={[Function]}
+            onMouseDown={[Function]}
             onMouseEnter={[Function]}
           >
             Go there


### PR DESCRIPTION
## Fix safari bug - inner anchors of TopNav dropdown don't navigate pages - [Trello ticket](https://trello.com/c/5Pc4ri1e/461-desktop-dropdown-issue-on-safari-is-back-clicking-on-link-makes-dropdown-collapse-but-doesnt-navigate-to-a-new-page)

#### Background
Console logging in Safari shows that `onMouseDown` does not fire on the InnerAnchorItem, when it is clicked.

Our understanding is that, onMouseDown propagates up to DropdownContainer, which changes the `isExpanded` prop (re-added in PR https://github.com/yldio/yld.io/pull/171). When this prop changes, the whole dropdown is re-rendered & navigation doesn't occur. Tbh we're unclear on what is different about Safari from other browsers, to cause this problem.

#### This PR will...
- revert PR https://github.com/yldio/yld.io/pull/172, which removed onMouseDown from InnerAnchorItem
- add `e.stopPropagation` on the inner anchor items, so that `isExpanded: !this.state.isExpanded` doesn't happen on an inner anchor click

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
