### PR TITLE
feat: add space to theme and documented it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # YLD Website
 
+
 ## [Link](https://yldio.io/)
 
 ## [Storybook](https://yld-storybook.now.sh)

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -22,6 +22,17 @@ export const spacing = {
   90: remcalc(90)
 }
 
+export const space = [
+  '0', // 0
+  remcalc(12), // 1
+  remcalc(24), // 2
+  remcalc(36), // 3
+  remcalc(54), // 4
+  remcalc(72), // 5
+  remcalc(108), // 6
+  remcalc(144) // 7
+]
+
 export const breakpoints = {
   smallPhone: 0,
   phone: 471,
@@ -56,6 +67,7 @@ const colorsVariables = {
 export default {
   breakpoints,
   spacing,
+  space,
   elementSizes,
   zIndexes,
   variations: {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -7822,6 +7822,298 @@ exports[`Storyshots Image with file url 1`] = `
 />
 `;
 
+exports[`Storyshots Spaces Spaces 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      1
+       - 
+      12
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "0.75rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      2
+       - 
+      24
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "1.5rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      3
+       - 
+      36
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "2.25rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      4
+       - 
+      54
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "3.375rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      5
+       - 
+      72
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "4.5rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      6
+       - 
+      108
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "6.75rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "margin": 10,
+        "position": "relative",
+      }
+    }
+  >
+    <p
+      style={
+        Object {
+          "color": "red",
+          "fontSize": 12,
+          "left": "50%",
+          "opacity": 0.5,
+          "position": "absolute",
+          "textAlign": "center",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "100%",
+        }
+      }
+    >
+      Level 
+      7
+       - 
+      144
+      px
+    </p>
+    <div
+      style={
+        Object {
+          "background": "#FFE5E5",
+          "height": "9rem",
+          "width": 160,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`Storyshots Standalone Video Link Dark theme 1`] = `
 .c3 {
   -webkit-flex-wrap: wrap;

--- a/stories/spaces.stories.js
+++ b/stories/spaces.stories.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import { storiesOf, addDecorator } from '@storybook/react'
+import Theme from './theme'
+import theme from '../src/utils/theme'
+
+addDecorator(Theme)
+
+storiesOf('Spaces', module).add('Spaces', () => (
+  <div>
+    {theme.space.map((space, idx) =>
+      space !== '0' ? (
+        <div
+          key={idx}
+          style={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            margin: 10
+          }}
+        >
+          <p
+            style={{
+              position: 'absolute',
+              opacity: 0.5,
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              fontSize: 12,
+              color: 'red',
+              width: '100%',
+              textAlign: 'center'
+            }}
+          >
+            Level {idx} - {space.replace('rem', '') * 16}px
+          </p>
+          <div
+            style={{
+              width: 160,
+              height: space,
+              background: '#FFE5E5'
+            }}
+          />
+        </div>
+      ) : null
+    )}
+  </div>
+))


### PR DESCRIPTION
## Description 

Having studied a bit the styling libs used in the project (styled-components, styled-system, styled-components-breakpoint, etc), I think they're really very powerful but we're not taking full advantage of them, namely on the `space scale` matter.

I just discovered last week that we have [this](https://app.zeplin.io/project/5b4e666f0d4230a16dffd93a/screen/5c0019f7e25494019fe389aa) documentation around our spacing rules, which is very handy for our spacing (margin/padding) definitions inside components.

Currently, we're defining spacing with the `styled-components-spacing` lib, which has `Margin` and `Padding` components. While — for some — this may simplify the space definition, I think it creates unnecessary levels of indentation and (worse) adds much more DOM nodes than we'd need. On top of it, we have to create a `spacing` variable in our theme, which got out of hand (a JS object with numbers as keys, and a scale which stopped being a scale at some point).

[https://styled-system.com](https://styled-system.com) handles this spacing — IMO — in a more elegant way, we're you can use style functions to enhance our components with new styling capacities. 

So, for example if you want to style `<div>` element with our `space scale`, you can do:

```js
import styled from 'styled-components'
import { space } from 'styled-system'

const Container = styled.div`
  ${space}
`
// when using it on a render fn, we can do:
<Container ml={1} mr={2} my={3}>
    ... content
</Container>
```

This way our div will have:
- the first scale value as the margin left
- the second as the margin right
- the third as the bottom and top margins

And we can still use responsive styles:
```js
<Container m={[1, 2, 3]}>
    ... content
</Container>
```
This way our div will have:
- the first scale value as the margin for our **first** breakpoint
- the second as the margin for our **second** breakpoint
- the third as the margin for our **third** breakpoint and larger screens

With this, we can document our layout spacings on a story and refer to it every time it's needed.

![image](https://user-images.githubusercontent.com/3236388/55740459-096cef00-5a23-11e9-8262-41edf7040ace.png)


This MR aims to open this discussion so as we can study the possibility of removing the `styled-components-spacing` lib and its usages from the project. 

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
