### PR TITLE
fix: add font family styles to storybook

### DIFF
--- a/stories/theme.js
+++ b/stories/theme.js
@@ -1,13 +1,18 @@
-import { ThemeProvider } from 'styled-components'
+import { ThemeProvider, createGlobalStyle } from 'styled-components'
 import React, { Fragment } from 'react'
+
 import theme from '../src/utils/theme'
 import GlobalStyle from '../src/utils/globalStyle'
+const FontsStyle = createGlobalStyle`
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,500,700');
+`
 
 const Theme = storyFn => (
   <ThemeProvider theme={theme}>
     <Fragment>
       {storyFn()}
       <GlobalStyle />
+      <FontsStyle />
     </Fragment>
   </ThemeProvider>
 )


### PR DESCRIPTION
## Description

Since our font family declarations are done in the `html.js` file (to speed up their fetching), they were not being added to the storybook stories. 

This PR fixes this issue.

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
