### PR TITLE
Topnav persistance on scrolling

### DIFF
--- a/src/components/Header/Hamburger.js
+++ b/src/components/Header/Hamburger.js
@@ -16,10 +16,25 @@ const HamburgerSvg = styled.svg`
 const HamburgerButton = styled(UnstyledButton)`
   ${breakpoint('smallPhone')`
     position: absolute;
-    right: 0;
     top: 0;
     width: ${remcalc(80)};
     height: ${remcalc(80)};
+
+    ${breakpoint('smallPhone')`
+      right: ${remcalc(24)};
+    `}
+
+    ${breakpoint('phone')`
+      right: ${remcalc(36)};
+    `}
+
+    ${breakpoint('largePhone')`
+      right: calc(50% - 240px);
+    `}
+
+    ${breakpoint('smallTablet')`
+      right: 0;
+    `}
 
     margin: ${remcalc(4)} ${remcalc(-20)} ${remcalc(4)} ${remcalc(4)};
     ${outlineStyles}

--- a/src/components/Header/Hamburger.js
+++ b/src/components/Header/Hamburger.js
@@ -16,26 +16,10 @@ const HamburgerSvg = styled.svg`
 const HamburgerButton = styled(UnstyledButton)`
   ${breakpoint('smallPhone')`
     position: absolute;
+    right: 0;
     top: 0;
     width: ${remcalc(80)};
     height: ${remcalc(80)};
-
-    ${breakpoint('smallPhone')`
-      right: ${remcalc(24)};
-    `}
-
-    ${breakpoint('phone')`
-      right: ${remcalc(36)};
-    `}
-
-    ${breakpoint('largePhone')`
-      right: calc(50% - 240px);
-    `}
-
-    ${breakpoint('smallTablet')`
-      right: 0;
-    `}
-
     margin: ${remcalc(4)} ${remcalc(-20)} ${remcalc(4)} ${remcalc(4)};
     ${outlineStyles}
   `}

--- a/src/components/Header/TopNav/ServiceLink.js
+++ b/src/components/Header/TopNav/ServiceLink.js
@@ -3,14 +3,14 @@ import { Link } from 'gatsby'
 import styled from 'styled-components'
 import remcalc from 'remcalc'
 import { capitalize } from 'lodash'
-import theme from '../../../../src/utils/theme'
 
 import { servicesRegExp, getSpecialityService } from './ServicesSpecialitiesMap'
 
 const StyledServiceLink = styled(Link)`
   font-size: ${remcalc(26)};
   margin-left: ${remcalc(12)};
-  color: ${props => props.color};
+  color: ${props =>
+    props.theme.colors[props.isServicePage ? 'black' : 'white']};
 
   @media screen and (min-width: 960px) {
     font-size: ${remcalc(30)};
@@ -18,7 +18,8 @@ const StyledServiceLink = styled(Link)`
 
   &:hover {
     text-decoration: underline;
-    color: ${props => props.color};
+    color: ${props =>
+      props.theme.colors[props.isServicePage ? 'black' : 'white']};
   }
 `
 
@@ -32,10 +33,7 @@ const ServiceLink = ({ path = '/' }) => {
   return (
     <Fragment>
       {isServicePage || isSpecialityPage ? (
-        <StyledServiceLink
-          to={`/${service}`}
-          color={theme.colors[isServicePage ? 'black' : 'white']}
-        >
+        <StyledServiceLink to={`/${service}`} isServicePage={isServicePage}>
           {capitalize(service)}
         </StyledServiceLink>
       ) : null}

--- a/src/components/Header/TopNav/ServiceLink.js
+++ b/src/components/Header/TopNav/ServiceLink.js
@@ -3,12 +3,14 @@ import { Link } from 'gatsby'
 import styled from 'styled-components'
 import remcalc from 'remcalc'
 import { capitalize } from 'lodash'
+import theme from '../../../../src/utils/theme'
 
 import { servicesRegExp, getSpecialityService } from './ServicesSpecialitiesMap'
 
 const StyledServiceLink = styled(Link)`
   font-size: ${remcalc(26)};
   margin-left: ${remcalc(12)};
+  color: ${props => props.color};
 
   @media screen and (min-width: 960px) {
     font-size: ${remcalc(30)};
@@ -16,7 +18,7 @@ const StyledServiceLink = styled(Link)`
 
   &:hover {
     text-decoration: underline;
-    color: ${props => props.hoverColor};
+    color: ${props => props.color};
   }
 `
 
@@ -32,7 +34,7 @@ const ServiceLink = ({ path = '/' }) => {
       {isServicePage || isSpecialityPage ? (
         <StyledServiceLink
           to={`/${service}`}
-          hoverColor={isServicePage ? 'black' : 'white'}
+          color={theme.colors[isServicePage ? 'black' : 'white']}
         >
           {capitalize(service)}
         </StyledServiceLink>

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -8,7 +8,7 @@ import ServiceLink from './ServiceLink'
 import OuterAnchorItem from './OuterAnchorItem'
 import Dropdown from './Dropdown'
 
-const StyledTopNavContainer = styled.div`
+const StyledTopNavContainer = styled.nav`
   display: flex;
   justify-content: space-between;
   width: 100%;
@@ -29,7 +29,6 @@ const TopNavList = styled.ul`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    flex: 1;
     padding: ${remcalc(20)} ${remcalc(0)} ${remcalc(16)};
     padding-right: ${remcalc(0)};
   }
@@ -41,37 +40,35 @@ const TopNav = ({ links, themeVariation, path }) => (
       <LogoLink path={path} />
       <ServiceLink path={path} />
     </StyledLinksContainer>
-    <nav>
-      <TopNavList>
-        {links.map((link, idx) => {
-          if (link.dropdownItems) {
-            const { label, dropdownItems } = link
-            return (
-              <Dropdown
-                key={idx}
-                themeVariation={themeVariation}
-                items={dropdownItems}
-              >
-                {label}
-              </Dropdown>
-            )
-          } else {
-            const { label, to, href } = link
-            return (
-              <OuterAnchorItem
-                key={idx}
-                themeVariation={themeVariation}
-                activeClassName="active"
-                to={to}
-                href={href}
-              >
-                {label}
-              </OuterAnchorItem>
-            )
-          }
-        })}
-      </TopNavList>
-    </nav>
+    <TopNavList>
+      {links.map((link, idx) => {
+        if (link.dropdownItems) {
+          const { label, dropdownItems } = link
+          return (
+            <Dropdown
+              key={idx}
+              themeVariation={themeVariation}
+              items={dropdownItems}
+            >
+              {label}
+            </Dropdown>
+          )
+        } else {
+          const { label, to, href } = link
+          return (
+            <OuterAnchorItem
+              key={idx}
+              themeVariation={themeVariation}
+              activeClassName="active"
+              to={to}
+              href={href}
+            >
+              {label}
+            </OuterAnchorItem>
+          )
+        }
+      })}
+    </TopNavList>
   </StyledTopNavContainer>
 )
 

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import styled from 'styled-components'
 import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
@@ -7,15 +7,6 @@ import LogoLink from './LogoLink'
 import ServiceLink from './ServiceLink'
 import OuterAnchorItem from './OuterAnchorItem'
 import Dropdown from './Dropdown'
-
-const StyledTopNavContainer = styled.div`
-  position: fixed;
-  width: ${remcalc(1100)};
-  display: flex;
-  justify-content: space-between;
-  background: white;
-  z-index: 100;
-`
 
 const StyledLinksContainer = styled.div`
   display: flex;
@@ -38,7 +29,7 @@ const TopNavList = styled.ul`
 `
 
 const TopNav = ({ links, themeVariation, path }) => (
-  <StyledTopNavContainer>
+  <Fragment>
     <StyledLinksContainer>
       <LogoLink path={path} />
       <ServiceLink path={path} />
@@ -74,7 +65,7 @@ const TopNav = ({ links, themeVariation, path }) => (
         })}
       </TopNavList>
     </nav>
-  </StyledTopNavContainer>
+  </Fragment>
 )
 
 export default TopNav

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -12,9 +12,13 @@ const StyledTopNavContainer = styled.div`
   display: flex;
   justify-content: space-between;
 
-  ${breakpoint('tablet')`
-    width: ${remcalc(1100)};
+  ${breakpoint('smallTablet')`
+    width: 100%;
   `}
+
+  ${breakpoint('desktop')`
+    width: ${remcalc(1100)};
+  `};
 `
 
 const StyledLinksContainer = styled.div`

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
@@ -7,6 +7,12 @@ import LogoLink from './LogoLink'
 import ServiceLink from './ServiceLink'
 import OuterAnchorItem from './OuterAnchorItem'
 import Dropdown from './Dropdown'
+
+const StyledTopNavContainer = styled.div`
+  width: ${remcalc(1100)};
+  display: flex;
+  justify-content: space-between;
+`
 
 const StyledLinksContainer = styled.div`
   display: flex;
@@ -29,7 +35,7 @@ const TopNavList = styled.ul`
 `
 
 const TopNav = ({ links, themeVariation, path }) => (
-  <Fragment>
+  <StyledTopNavContainer>
     <StyledLinksContainer>
       <LogoLink path={path} />
       <ServiceLink path={path} />
@@ -65,7 +71,7 @@ const TopNav = ({ links, themeVariation, path }) => (
         })}
       </TopNavList>
     </nav>
-  </Fragment>
+  </StyledTopNavContainer>
 )
 
 export default TopNav

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -12,7 +12,20 @@ const StyledTopNavContainer = styled.div`
   display: flex;
   justify-content: space-between;
 
+  ${breakpoint('smallPhone')`
+    padding-left: ${remcalc(24)};
+  `}
+
+  ${breakpoint('phone')`
+    padding-left: ${remcalc(36)};
+  `}
+
+  ${breakpoint('largePhone')`
+    padding-left: calc(50% - 240px);
+  `}
+
   ${breakpoint('smallTablet')`
+    padding-left: 0;
     width: 100%;
   `}
 

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -12,9 +12,9 @@ const StyledTopNavContainer = styled.div`
   display: flex;
   justify-content: space-between;
 
-  @media screen and (min-width: 960px) {
+  ${breakpoint('tablet')`
     width: ${remcalc(1100)};
-  }
+  `}
 `
 
 const StyledLinksContainer = styled.div`

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
@@ -7,6 +7,15 @@ import LogoLink from './LogoLink'
 import ServiceLink from './ServiceLink'
 import OuterAnchorItem from './OuterAnchorItem'
 import Dropdown from './Dropdown'
+
+const StyledTopNavContainer = styled.div`
+  position: fixed;
+  width: ${remcalc(1100)};
+  display: flex;
+  justify-content: space-between;
+  background: white;
+  z-index: 100;
+`
 
 const StyledLinksContainer = styled.div`
   display: flex;
@@ -29,7 +38,7 @@ const TopNavList = styled.ul`
 `
 
 const TopNav = ({ links, themeVariation, path }) => (
-  <Fragment>
+  <StyledTopNavContainer>
     <StyledLinksContainer>
       <LogoLink path={path} />
       <ServiceLink path={path} />
@@ -65,7 +74,7 @@ const TopNav = ({ links, themeVariation, path }) => (
         })}
       </TopNavList>
     </nav>
-  </Fragment>
+  </StyledTopNavContainer>
 )
 
 export default TopNav

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -11,27 +11,8 @@ import Dropdown from './Dropdown'
 const StyledTopNavContainer = styled.div`
   display: flex;
   justify-content: space-between;
-
-  ${breakpoint('smallPhone')`
-    padding-left: ${remcalc(24)};
-  `}
-
-  ${breakpoint('phone')`
-    padding-left: ${remcalc(36)};
-  `}
-
-  ${breakpoint('largePhone')`
-    padding-left: calc(50% - 240px);
-  `}
-
-  ${breakpoint('smallTablet')`
-    padding-left: 0;
-    width: 100%;
-  `}
-
-  ${breakpoint('desktop')`
-    width: ${remcalc(1100)};
-  `};
+  width: 100%;
+  height: ${remcalc(84)};
 `
 
 const StyledLinksContainer = styled.div`

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -9,9 +9,12 @@ import OuterAnchorItem from './OuterAnchorItem'
 import Dropdown from './Dropdown'
 
 const StyledTopNavContainer = styled.div`
-  width: ${remcalc(1100)};
   display: flex;
   justify-content: space-between;
+
+  @media screen and (min-width: 960px) {
+    width: ${remcalc(1100)};
+  }
 `
 
 const StyledLinksContainer = styled.div`

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useState, useEffect } from 'react'
 
 import styled from 'styled-components'
 import Flex from 'styled-flex-component'
@@ -27,7 +27,8 @@ const StyledGrid = styled(Grid)`
   width: 100%;
   max-width: unset;
   z-index: 100;
-  box-shadow: ${props => `0 9px 9px -9px ${props.theme.colors.border}`};
+  box-shadow: ${props =>
+    props.hasShadow ? `0 9px 9px -9px ${props.theme.colors.border}` : null};
 
   ${breakpoint('smallTablet')`
     max-width: none;
@@ -42,17 +43,27 @@ const StyledGrid = styled(Grid)`
   `}
 `
 
+// nb: training/ and training/#node-js for example are navigation pages and still render the header
 const trainingModalRegExp = /training\/(node|react|engineering-skills|development-tools)/
 
 const Header = ({ path, blue }) => {
   const [isSideNavOpen, toggleSideNav] = useState(false)
+  const [isScrolling, setScrolling] = useState(false)
   const isSpecialityPage = path.includes('speciality')
   const isModalPage = !!path.match(trainingModalRegExp)
+
+  useEffect(() => {
+    document.addEventListener('scroll', handleScroll)
+    return () => document.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  const handleScroll = () =>
+    setScrolling(document.documentElement.scrollTop !== 0)
 
   return (
     <Fragment>
       {!isModalPage ? (
-        <StyledGrid isSpecialityPage={isSpecialityPage}>
+        <StyledGrid isSpecialityPage={isSpecialityPage} hasShadow={isScrolling}>
           <Row style={{ overflow: 'visible' }}>
             <Col width={[1]} style={{ overflow: 'visible' }}>
               <StyledPadding bottom={3}>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -62,8 +62,6 @@ const StyledGrid = styled(Grid)`
   height: ${remcalc(84)};
   right: 50%;
   margin-right: -${remcalc(550)};
-  display: flex;
-  justify-content: space-between;
   background: white;
   z-index: 100;
 `

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -59,14 +59,14 @@ const navLinks = [
 
 const StyledGrid = styled(Grid)`
   position: fixed;
-  width: 100%;
   height: ${remcalc(84)};
   background: white;
+  width: 100%;
+  max-width: unset;
   z-index: 100;
   box-shadow: 0 9px 9px -9px lightgrey;
 
   ${breakpoint('desktop')`
-    max-width: unset;
     right: 50%;
     margin-right: -50%;
     display: flex;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -60,6 +60,8 @@ const StyledGrid = styled(Grid)`
   position: fixed;
   width: ${remcalc(1100)};
   height: ${remcalc(84)};
+  right: 50%;
+  margin-right: -${remcalc(550)};
   display: flex;
   justify-content: space-between;
   background: white;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { Fragment, useState } from 'react'
 
 import styled from 'styled-components'
 import Flex from 'styled-flex-component'
@@ -42,40 +42,47 @@ const StyledGrid = styled(Grid)`
   `}
 `
 
+const trainingModalRegExp = /training\/(node|react|engineering-skills|development-tools)/
+
 const Header = ({ path, blue }) => {
   const [isSideNavOpen, toggleSideNav] = useState(false)
   const isSpecialityPage = path.includes('speciality')
+  const isModalPage = !!path.match(trainingModalRegExp)
 
   return (
-    <StyledGrid isSpecialityPage={isSpecialityPage}>
-      <Row style={{ overflow: 'visible' }}>
-        <Col width={[1]} style={{ overflow: 'visible' }}>
-          <StyledPadding bottom={3}>
-            <Flex alignCenter justifyBetween full as="header">
-              <TopNav
-                path={path}
-                links={navLinks}
-                themeVariation={blue ? 'dark' : 'light'}
-              />
-              <Hamburger
-                onClick={() => toggleSideNav(true)}
-                themeVariation={blue ? 'dark' : 'light'}
-              />
-              <Overlay
-                visible={isSideNavOpen}
-                onClick={() => toggleSideNav(false)}
-              />
-              <SideNav
-                links={navLinks}
-                themeVariation="dark"
-                isOpen={isSideNavOpen}
-                onClose={() => toggleSideNav(false)}
-              />
-            </Flex>
-          </StyledPadding>
-        </Col>
-      </Row>
-    </StyledGrid>
+    <Fragment>
+      {!isModalPage ? (
+        <StyledGrid isSpecialityPage={isSpecialityPage}>
+          <Row style={{ overflow: 'visible' }}>
+            <Col width={[1]} style={{ overflow: 'visible' }}>
+              <StyledPadding bottom={3}>
+                <Flex alignCenter justifyBetween full as="header">
+                  <TopNav
+                    path={path}
+                    links={navLinks}
+                    themeVariation={blue ? 'dark' : 'light'}
+                  />
+                  <Hamburger
+                    onClick={() => toggleSideNav(true)}
+                    themeVariation={blue ? 'dark' : 'light'}
+                  />
+                  <Overlay
+                    visible={isSideNavOpen}
+                    onClick={() => toggleSideNav(false)}
+                  />
+                  <SideNav
+                    links={navLinks}
+                    themeVariation="dark"
+                    isOpen={isSideNavOpen}
+                    onClose={() => toggleSideNav(false)}
+                  />
+                </Flex>
+              </StyledPadding>
+            </Col>
+          </Row>
+        </StyledGrid>
+      ) : null}
+    </Fragment>
   )
 }
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -19,8 +19,8 @@ const StyledContainer = styled.div`
     props.hasShadow ? `0 9px 9px -9px rgba(0, 0, 0, 0.175)` : null};
 `
 
-// nb: training/ and training/#node-js for example are navigation pages and still render the header
-const trainingModalRegExp = /training\/(node|react|engineering-skills|development-tools)/
+// nb: at the moment only the training service has modals pages. Modals match this RegExp:
+const trainingModalRegExp = /training\/[a-zA-Z]/
 
 const Header = ({ path, blue }) => {
   const [isSideNavOpen, toggleSideNav] = useState(false)

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -62,6 +62,7 @@ const StyledGrid = styled(Grid)`
   height: ${remcalc(84)};
   background: white;
   z-index: 100;
+  box-shadow: 0 9px 9px -9px lightgrey;
 
   @media screen and (min-width: 960px) {
     max-width: unset;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -29,21 +29,6 @@ const StyledGrid = styled(Grid)`
   z-index: 100;
   box-shadow: ${props => `0 9px 9px -9px ${props.theme.colors.border}`};
 
-  ${breakpoint('smallPhone')`
-    max-width: calc(100% - 48px);
-    margin: 0 ${remcalc(24)};
-  `}
-
-  ${breakpoint('phone')`
-    max-width: calc(100% - 72px);
-    margin: 0 ${remcalc(36)};
-  `}
-
-  ${breakpoint('largePhone')`
-    max-width: ${remcalc(480)};
-    margin: 0 calc(50% - 240px);
-  `}
-
   ${breakpoint('smallTablet')`
     max-width: none;
     margin: 0 auto;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -73,9 +73,29 @@ const StyledGrid = styled(Grid)`
   z-index: 100;
   box-shadow: ${props => `0 9px 9px -9px ${props.theme.colors.border}`};
 
+  ${breakpoint('smallPhone')`
+    max-width: calc(100% - 48px);
+    margin: 0 ${remcalc(24)};
+  `}
+
+  ${breakpoint('phone')`
+    max-width: calc(100% - 72px);
+    margin: 0 ${remcalc(36)};
+  `}
+
+  ${breakpoint('largePhone')`
+    max-width: ${remcalc(480)};
+    margin: 0 calc(50% - 240px);
+  `}
+
+  ${breakpoint('smallTablet')`
+    max-width: none;
+    margin: 0 auto;
+  `}
+
   ${breakpoint('desktop')`
     right: 50%;
-    margin-right: -50%;
+    margin: 0 -50% 0 0;
     display: flex;
     justify-content: center;
   `}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import Flex from 'styled-flex-component'
 import { Padding } from 'styled-components-spacing'
+import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
 
 import { Row, Col, Grid } from '../grid'
@@ -64,13 +65,13 @@ const StyledGrid = styled(Grid)`
   z-index: 100;
   box-shadow: 0 9px 9px -9px lightgrey;
 
-  @media screen and (min-width: 960px) {
+  ${breakpoint('desktop')`
     max-width: unset;
     right: 50%;
     margin-right: -50%;
     display: flex;
     justify-content: center;
-  }
+  `}
 `
 
 const Header = ({ path, blue }) => {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,6 +1,5 @@
 import React, { Fragment, useState, useEffect } from 'react'
 import styled from 'styled-components'
-import Flex from 'styled-flex-component'
 import remcalc from 'remcalc'
 
 import navLinks from './navLinks'
@@ -54,27 +53,25 @@ const Header = ({ path, blue }) => {
           <Grid>
             <Row style={{ overflow: 'visible' }}>
               <Col width={[1]} style={{ overflow: 'visible' }}>
-                <Flex alignCenter justifyBetween full as="header">
-                  <TopNav
-                    path={path}
-                    links={navLinks}
-                    themeVariation={blue ? 'dark' : 'light'}
-                  />
-                  <Hamburger
-                    onClick={() => toggleSideNav(true)}
-                    themeVariation={blue ? 'dark' : 'light'}
-                  />
-                  <Overlay
-                    visible={isSideNavOpen}
-                    onClick={() => toggleSideNav(false)}
-                  />
-                  <SideNav
-                    links={navLinks}
-                    themeVariation="dark"
-                    isOpen={isSideNavOpen}
-                    onClose={() => toggleSideNav(false)}
-                  />
-                </Flex>
+                <TopNav
+                  path={path}
+                  links={navLinks}
+                  themeVariation={blue ? 'dark' : 'light'}
+                />
+                <Hamburger
+                  onClick={() => toggleSideNav(true)}
+                  themeVariation={blue ? 'dark' : 'light'}
+                />
+                <Overlay
+                  visible={isSideNavOpen}
+                  onClick={() => toggleSideNav(false)}
+                />
+                <SideNav
+                  links={navLinks}
+                  themeVariation="dark"
+                  isOpen={isSideNavOpen}
+                  onClose={() => toggleSideNav(false)}
+                />
               </Col>
             </Row>
           </Grid>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -26,14 +26,7 @@ const StyledGrid = styled(Grid)`
   max-width: unset;
   z-index: ${props => props.theme.zIndexes.header};
 
-  ${breakpoint('smallTablet')`
-    max-width: none;
-    margin: 0 auto;
-  `}
-
   ${breakpoint('desktop')`
-    right: 50%;
-    margin: 0 -50% 0 0;
     display: flex;
     justify-content: center;
   `}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,9 +1,6 @@
 import React, { Fragment, useState, useEffect } from 'react'
-
 import styled from 'styled-components'
 import Flex from 'styled-flex-component'
-import { Padding } from 'styled-components-spacing'
-import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
 
 import navLinks from './navLinks'
@@ -13,23 +10,13 @@ import Overlay from './Overlay'
 import TopNav from './TopNav'
 import SideNav from './SideNav'
 
-const StyledPadding = styled(Padding)`
-  height: ${remcalc(120)};
-`
-
-const StyledGrid = styled(Grid)`
+const StyledContainer = styled.div`
   position: fixed;
-  height: ${remcalc(84)};
   background: ${props =>
     props.theme.colors[props.isSpecialityPage ? 'blueBg' : 'white']};
   width: 100%;
   max-width: unset;
   z-index: ${props => props.theme.zIndexes.header};
-
-  ${breakpoint('desktop')`
-    display: flex;
-    justify-content: center;
-  `}
 `
 
 const StyledShadowGradient = styled.div`
@@ -62,11 +49,11 @@ const Header = ({ path, blue }) => {
   return (
     <Fragment>
       {!isModalPage ? (
-        <StyledGrid isSpecialityPage={isSpecialityPage}>
+        <StyledContainer isSpecialityPage={isSpecialityPage}>
           {isScrolled ? <StyledShadowGradient /> : null}
-          <Row style={{ overflow: 'visible' }}>
-            <Col width={[1]} style={{ overflow: 'visible' }}>
-              <StyledPadding bottom={3}>
+          <Grid>
+            <Row style={{ overflow: 'visible' }}>
+              <Col width={[1]} style={{ overflow: 'visible' }}>
                 <Flex alignCenter justifyBetween full as="header">
                   <TopNav
                     path={path}
@@ -88,10 +75,10 @@ const Header = ({ path, blue }) => {
                     onClose={() => toggleSideNav(false)}
                   />
                 </Flex>
-              </StyledPadding>
-            </Col>
-          </Row>
-        </StyledGrid>
+              </Col>
+            </Row>
+          </Grid>
+        </StyledContainer>
       ) : null}
     </Fragment>
   )

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -58,12 +58,18 @@ const navLinks = [
 
 const StyledGrid = styled(Grid)`
   position: fixed;
-  width: ${remcalc(1100)};
+  width: 100%;
   height: ${remcalc(84)};
-  right: 50%;
-  margin-right: -${remcalc(550)};
   background: white;
   z-index: 100;
+
+  @media screen and (min-width: 960px) {
+    max-width: unset;
+    right: 50%;
+    margin-right: -50%;
+    display: flex;
+    justify-content: center;
+  }
 `
 
 const Header = ({ path, blue }) => {

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import Flex from 'styled-flex-component'
 import { Padding } from 'styled-components-spacing'
+import remcalc from 'remcalc'
 
 import { Row, Col, Grid } from '../grid'
 import Hamburger from './Hamburger'
@@ -59,11 +60,20 @@ const navLinks = [
   }
 ]
 
+const StyledGrid = styled(Grid)`
+  position: fixed;
+  width: ${remcalc(1100)};
+  display: flex;
+  justify-content: space-between;
+  background: white;
+  z-index: 100;
+`
+
 const Header = ({ path, blue }) => {
   const [isSideNavOpen, toggleSideNav] = useState(false)
 
   return (
-    <Grid>
+    <StyledGrid>
       <Row style={{ overflow: 'visible' }}>
         <Col width={[1]} style={{ overflow: 'visible' }}>
           <Padding bottom={3}>
@@ -91,7 +101,7 @@ const Header = ({ path, blue }) => {
           </Padding>
         </Col>
       </Row>
-    </Grid>
+    </StyledGrid>
   )
 }
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -6,56 +6,12 @@ import { Padding } from 'styled-components-spacing'
 import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
 
+import navLinks from './navLinks'
 import { Row, Col, Grid } from '../grid'
 import Hamburger from './Hamburger'
 import Overlay from './Overlay'
 import TopNav from './TopNav'
 import SideNav from './SideNav'
-
-const navLinks = [
-  {
-    label: 'Services',
-    dropdownItems: [
-      {
-        label: 'Engineering',
-        to: '/engineering/'
-      },
-      {
-        label: 'Design',
-        to: '/design/'
-      },
-      {
-        label: 'Training',
-        to: '/training/'
-      }
-    ]
-  },
-  {
-    label: 'Our work',
-    to: '/our-work/'
-  },
-  {
-    label: 'Blog',
-    href: 'https://medium.com/yld-engineering-blog/'
-  },
-  {
-    label: 'About',
-    dropdownItems: [
-      {
-        label: 'Our team',
-        to: '/about-us/'
-      },
-      {
-        label: 'Contact',
-        to: '/contact/'
-      }
-    ]
-  },
-  {
-    label: 'Join us',
-    to: '/join-us/'
-  }
-]
 
 const StyledPadding = styled(Padding)`
   display: flex;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -110,7 +110,7 @@ const Header = ({ path, blue }) => {
       <Row style={{ overflow: 'visible' }}>
         <Col width={[1]} style={{ overflow: 'visible' }}>
           <StyledPadding bottom={3}>
-            <Flex alignCenter justifyBetween as="header">
+            <Flex alignCenter justifyBetween full as="header">
               <TopNav
                 path={path}
                 links={navLinks}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,6 +1,5 @@
 import React, { Fragment, useState, useEffect } from 'react'
 import styled from 'styled-components'
-import remcalc from 'remcalc'
 
 import navLinks from './navLinks'
 import { Row, Col, Grid } from '../grid'
@@ -16,16 +15,8 @@ const StyledContainer = styled.div`
   width: 100%;
   max-width: unset;
   z-index: ${props => props.theme.zIndexes.header};
-`
-
-const StyledShadowGradient = styled.div`
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  margin-top: ${remcalc(84)};
-  height: ${remcalc(9)};
-  width: 100%;
-  background-image: linear-gradient(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0));
+  box-shadow: ${props =>
+    props.hasShadow ? `0 9px 9px -9px rgba(0, 0, 0, 0.175)` : null};
 `
 
 // nb: training/ and training/#node-js for example are navigation pages and still render the header
@@ -48,8 +39,10 @@ const Header = ({ path, blue }) => {
   return (
     <Fragment>
       {!isModalPage ? (
-        <StyledContainer isSpecialityPage={isSpecialityPage}>
-          {isScrolled ? <StyledShadowGradient /> : null}
+        <StyledContainer
+          isSpecialityPage={isSpecialityPage}
+          hasShadow={isScrolled}
+        >
           <Grid>
             <Row style={{ overflow: 'visible' }}>
               <Col width={[1]} style={{ overflow: 'visible' }}>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -27,8 +27,6 @@ const StyledGrid = styled(Grid)`
   width: 100%;
   max-width: unset;
   z-index: 100;
-  box-shadow: ${props =>
-    props.hasShadow ? `0 9px 9px -9px ${props.theme.colors.border}` : null};
 
   ${breakpoint('smallTablet')`
     max-width: none;
@@ -43,12 +41,22 @@ const StyledGrid = styled(Grid)`
   `}
 `
 
+const StyledShadowGradient = styled.div`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: ${remcalc(84)};
+  height: ${remcalc(9)};
+  width: 100%;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0));
+`
+
 // nb: training/ and training/#node-js for example are navigation pages and still render the header
 const trainingModalRegExp = /training\/(node|react|engineering-skills|development-tools)/
 
 const Header = ({ path, blue }) => {
   const [isSideNavOpen, toggleSideNav] = useState(false)
-  const [isScrolling, setScrolling] = useState(false)
+  const [isScrolled, setIsScrolled] = useState(false)
   const isSpecialityPage = path.includes('speciality')
   const isModalPage = !!path.match(trainingModalRegExp)
 
@@ -58,12 +66,13 @@ const Header = ({ path, blue }) => {
   }, [])
 
   const handleScroll = () =>
-    setScrolling(document.documentElement.scrollTop !== 0)
+    setIsScrolled(document.documentElement.scrollTop !== 0)
 
   return (
     <Fragment>
       {!isModalPage ? (
-        <StyledGrid isSpecialityPage={isSpecialityPage} hasShadow={isScrolling}>
+        <StyledGrid isSpecialityPage={isSpecialityPage}>
+          {isScrolled ? <StyledShadowGradient /> : null}
           <Row style={{ overflow: 'visible' }}>
             <Col width={[1]} style={{ overflow: 'visible' }}>
               <StyledPadding bottom={3}>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -60,11 +60,12 @@ const navLinks = [
 const StyledGrid = styled(Grid)`
   position: fixed;
   height: ${remcalc(84)};
-  background: ${props => (props.isSpecialityPage ? '#090329' : 'white')};
+  background: ${props =>
+    props.theme.colors[props.isSpecialityPage ? 'blueBg' : 'white']};
   width: 100%;
   max-width: unset;
   z-index: 100;
-  box-shadow: 0 9px 9px -9px lightgrey;
+  box-shadow: ${props => `0 9px 9px -9px ${props.theme.colors.border}`};
 
   ${breakpoint('desktop')`
     right: 50%;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -57,6 +57,12 @@ const navLinks = [
   }
 ]
 
+const StyledPadding = styled(Padding)`
+  display: flex;
+  height: ${remcalc(120)};
+  align-items: center;
+`
+
 const StyledGrid = styled(Grid)`
   position: fixed;
   height: ${remcalc(84)};
@@ -83,7 +89,7 @@ const Header = ({ path, blue }) => {
     <StyledGrid isSpecialityPage={isSpecialityPage}>
       <Row style={{ overflow: 'visible' }}>
         <Col width={[1]} style={{ overflow: 'visible' }}>
-          <Padding bottom={3}>
+          <StyledPadding bottom={3}>
             <Flex alignCenter justifyBetween as="header">
               <TopNav
                 path={path}
@@ -105,7 +111,7 @@ const Header = ({ path, blue }) => {
                 onClose={() => toggleSideNav(false)}
               />
             </Flex>
-          </Padding>
+          </StyledPadding>
         </Col>
       </Row>
     </StyledGrid>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -60,7 +60,7 @@ const navLinks = [
 const StyledGrid = styled(Grid)`
   position: fixed;
   height: ${remcalc(84)};
-  background: white;
+  background: ${props => (props.isSpecialityPage ? '#090329' : 'white')};
   width: 100%;
   max-width: unset;
   z-index: 100;
@@ -76,9 +76,10 @@ const StyledGrid = styled(Grid)`
 
 const Header = ({ path, blue }) => {
   const [isSideNavOpen, toggleSideNav] = useState(false)
+  const isSpecialityPage = path.includes('speciality')
 
   return (
-    <StyledGrid>
+    <StyledGrid isSpecialityPage={isSpecialityPage}>
       <Row style={{ overflow: 'visible' }}>
         <Col width={[1]} style={{ overflow: 'visible' }}>
           <Padding bottom={3}>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -11,10 +11,6 @@ import Overlay from './Overlay'
 import TopNav from './TopNav'
 import SideNav from './SideNav'
 
-const FixedHeightFlex = styled(Flex)`
-  height: 84px;
-`
-
 const navLinks = [
   {
     label: 'Services',
@@ -63,6 +59,7 @@ const navLinks = [
 const StyledGrid = styled(Grid)`
   position: fixed;
   width: ${remcalc(1100)};
+  height: ${remcalc(84)};
   display: flex;
   justify-content: space-between;
   background: white;
@@ -77,7 +74,7 @@ const Header = ({ path, blue }) => {
       <Row style={{ overflow: 'visible' }}>
         <Col width={[1]} style={{ overflow: 'visible' }}>
           <Padding bottom={3}>
-            <FixedHeightFlex alignCenter justifyBetween as="header">
+            <Flex alignCenter justifyBetween as="header">
               <TopNav
                 path={path}
                 links={navLinks}
@@ -97,7 +94,7 @@ const Header = ({ path, blue }) => {
                 isOpen={isSideNavOpen}
                 onClose={() => toggleSideNav(false)}
               />
-            </FixedHeightFlex>
+            </Flex>
           </Padding>
         </Col>
       </Row>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -14,9 +14,7 @@ import TopNav from './TopNav'
 import SideNav from './SideNav'
 
 const StyledPadding = styled(Padding)`
-  display: flex;
   height: ${remcalc(120)};
-  align-items: center;
 `
 
 const StyledGrid = styled(Grid)`
@@ -26,7 +24,7 @@ const StyledGrid = styled(Grid)`
     props.theme.colors[props.isSpecialityPage ? 'blueBg' : 'white']};
   width: 100%;
   max-width: unset;
-  z-index: 100;
+  z-index: ${props => props.theme.zIndexes.header};
 
   ${breakpoint('smallTablet')`
     max-width: none;

--- a/src/components/Header/navLinks.js
+++ b/src/components/Header/navLinks.js
@@ -1,0 +1,46 @@
+const navLinks = [
+  {
+    label: 'Services',
+    dropdownItems: [
+      {
+        label: 'Engineering',
+        to: '/engineering/'
+      },
+      {
+        label: 'Design',
+        to: '/design/'
+      },
+      {
+        label: 'Training',
+        to: '/training/'
+      }
+    ]
+  },
+  {
+    label: 'Our work',
+    to: '/our-work/'
+  },
+  {
+    label: 'Blog',
+    href: 'https://medium.com/yld-engineering-blog/'
+  },
+  {
+    label: 'About',
+    dropdownItems: [
+      {
+        label: 'Our team',
+        to: '/about-us/'
+      },
+      {
+        label: 'Contact',
+        to: '/contact/'
+      }
+    ]
+  },
+  {
+    label: 'Join us',
+    to: '/join-us/'
+  }
+]
+
+export default navLinks

--- a/src/components/Speciality/Intro.js
+++ b/src/components/Speciality/Intro.js
@@ -1,14 +1,22 @@
 import React from 'react'
 import styled from 'styled-components'
+import Flex from 'styled-flex-component'
+import { Padding } from 'styled-components-spacing'
+import remcalc from 'remcalc'
+
 import { Row, Col, Grid } from '../grid'
 import { SectionTitle, CardTitle, Subtitle, BodyPrimary } from '../Typography'
-import { Padding } from 'styled-components-spacing'
 import BlueBackground from '../Common/BlueBackground'
-import Flex from 'styled-flex-component'
 
 const IntroBorder = styled(Col)`
   border: 1px solid rgba(255, 255, 255, 0.3);
 `
+
+const StyledBlueBackground = styled(BlueBackground)`
+  padding-top: ${remcalc(36)};
+  margin-top: -${remcalc(36)};
+`
+
 const IntroRectangle = ({ introTextTitle, introTextBody }) => (
   <IntroBorder width={[1, 1, 1, 1, 4 / 12]}>
     <Padding top={2} bottom={2}>
@@ -23,7 +31,7 @@ const IntroRectangle = ({ introTextTitle, introTextBody }) => (
 )
 
 const IntroSection = ({ speciality }) => (
-  <BlueBackground>
+  <StyledBlueBackground>
     <Padding top={2} bottom={5}>
       <Grid>
         <Row>
@@ -71,6 +79,6 @@ const IntroSection = ({ speciality }) => (
         </Col>
       </Grid>
     </Padding>
-  </BlueBackground>
+  </StyledBlueBackground>
 )
 export default IntroSection

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,8 +1,10 @@
 import React, { Fragment, Component } from 'react'
 import Helmet from 'react-helmet'
-import { ThemeProvider } from 'styled-components'
+import styled, { ThemeProvider } from 'styled-components'
 import { StaticQuery, graphql } from 'gatsby'
 import { Location } from '@reach/router'
+import remcalc from 'remcalc'
+
 import Header from './Header'
 import './layout.css'
 import BlueBackground from './Common/BlueBackground'
@@ -18,6 +20,10 @@ const googleJson = JSON.stringify(google)
 
 const isDevEnvironment =
   GATSBY_ENVIRONMENT === 'development' || GATSBY_ENVIRONMENT === 'preview'
+
+const StyledMain = styled.main`
+  padding-top: ${remcalc(120)};
+`
 
 class Layout extends Component {
   constructor(props) {
@@ -100,7 +106,7 @@ class Layout extends Component {
                   gutter={['24px', '36px', '36px', '42px', '48px']}
                 />
               )}
-              <main>{children}</main>
+              <StyledMain>{children}</StyledMain>
               <Footer />
               <GlobalStyle />
               {!this.state.cookiesAllowed && (

--- a/stories/TopNav.stories.js
+++ b/stories/TopNav.stories.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import { storiesOf, addDecorator } from '@storybook/react'
+import styled from 'styled-components'
+
 import Theme from './theme'
 import TopNav from '../src/components/Header/TopNav/'
+import theme from '../src/utils/theme'
 
 addDecorator(Theme)
 
@@ -22,7 +25,7 @@ const anchors = [
 
 const anchorsAndDropdowns = [
   {
-    label: 'First dropdown',
+    label: 'Dropdown 1',
     dropdownItems: [
       {
         label: 'Item 1',
@@ -39,15 +42,15 @@ const anchorsAndDropdowns = [
     ]
   },
   {
-    label: 'First anchor',
+    label: 'Anchor 1',
     to: '/anchor/'
   },
   {
-    label: 'LinkedIn (external anchor)',
+    label: 'External anchor',
     href: 'https://uk.linkedin.com/'
   },
   {
-    label: 'Second dropdown',
+    label: 'Dropdown 2',
     dropdownItems: [
       {
         label: 'Go here',
@@ -60,10 +63,15 @@ const anchorsAndDropdowns = [
     ]
   },
   {
-    label: 'Last anchor',
+    label: 'Anchor 2',
     to: '/last-anchor/'
   }
 ]
+
+const DarkThemedHeader = styled.header`
+  background: ${theme.colors.blueBg};
+  width: 100%;
+`
 
 storiesOf('Header', module)
   .add('TopNavbar - light theme', () => (
@@ -71,4 +79,16 @@ storiesOf('Header', module)
   ))
   .add('TopNavbar with dropdowns - light theme', () => (
     <TopNav links={anchorsAndDropdowns} themeVariation="light" />
+  ))
+  .add('TopNavbar - Service TopNavBar', () => (
+    <TopNav links={anchorsAndDropdowns} path="engineering" />
+  ))
+  .add('TopNavbar - Speciality TopNavBar', () => (
+    <DarkThemedHeader>
+      <TopNav
+        links={anchorsAndDropdowns}
+        path="speciality/node-js/"
+        themeVariation="dark"
+      />
+    </DarkThemedHeader>
   ))

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6633,7 +6633,6 @@ exports[`Storyshots Header Header itself 1`] = `
   width: 100%;
   max-width: unset;
   z-index: 100;
-  box-shadow: 0 9px 9px -9px #e6e6e6;
 }
 
 @media (min-width:29.4375em) {

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -7377,6 +7377,1080 @@ exports[`Storyshots Header Header itself 1`] = `
 </div>
 `;
 
+exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
+.c2 {
+  height: 3rem;
+  width: 3rem;
+}
+
+.c3 {
+  font-size: 1.625rem;
+  margin-left: 0.75rem;
+  color: #1d1d1d;
+}
+
+.c3:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #1d1d1d;
+}
+
+.c13 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c13:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c13:active {
+  outline: none;
+}
+
+.c12 {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #fff;
+  color: #333333;
+}
+
+.c12:hover,
+.c12 > a:hover {
+  background: #333333;
+  color: #a9a9a9;
+}
+
+.c12 > a:active {
+  background: #333333;
+  color: #fff;
+}
+
+.c12 > a.active {
+  background: #fff;
+  color: #828282;
+}
+
+.c12 > a.active:active {
+  background: #fff;
+  color: #828282;
+}
+
+.c12 > a.active:hover {
+  color: #333333;
+}
+
+.c8 {
+  stroke: currentColor;
+  stroke-width: 0.1875rem;
+  fill: none;
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+  -webkit-transition: -webkit-transform 0s ease 0.1s;
+  -webkit-transition: transform 0s ease 0.1s;
+  transition: transform 0s ease 0.1s;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c11 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+  width: 100%;
+  background: #f9f9f9;
+  color: #828282;
+}
+
+.c11:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c11:active {
+  outline: none;
+}
+
+.c11:hover,
+.c11.active {
+  color: #333333;
+}
+
+.c5 {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  position: relative;
+  cursor: pointer;
+  background: transparent;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
+.c5 > span {
+  background: #fff;
+  color: #333333;
+}
+
+.c5 > span:hover {
+  background: #333333;
+  color: #a9a9a9;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: outline 300ms ease-out;
+  transition: outline 300ms ease-out;
+  z-index: 2;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c6:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c6:active {
+  outline: none;
+}
+
+.c7 {
+  padding-right: 0.375rem;
+  outline: none;
+}
+
+.c9 {
+  position: absolute;
+  width: 10rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  top: 3rem;
+  left: -9999px;
+  opacity: 0;
+  -webkit-transition: opacity 300ms ease;
+  transition: opacity 300ms ease;
+  background: #f9f9f9;
+  z-index: 999;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 1.5rem;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  display: none;
+}
+
+@media screen and (min-width:960px) {
+  .c2 {
+    height: 3.375rem;
+    width: 3.375rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c3 {
+    font-size: 1.875rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c12 {
+    margin-right: 0.375rem;
+  }
+
+  .c12:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c5 {
+    margin-right: 0.375rem;
+  }
+
+  .c5:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media (min-width:29.4375em) {
+  .c0 {
+    padding-left: 2.25rem;
+  }
+}
+
+@media (min-width:34.5625em) {
+  .c0 {
+    padding-left: calc(50% - 240px);
+  }
+}
+
+@media (min-width:43.8125em) {
+  .c0 {
+    padding-left: 0;
+    width: 100%;
+  }
+}
+
+@media (min-width:74.8125em) {
+  .c0 {
+    width: 68.75rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c4 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    padding: 1.25rem 0rem 1rem;
+    padding-right: 0rem;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <a
+      aria-current="page"
+      className="c2"
+      href="/"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={Object {}}
+    >
+      <svg
+        viewBox="0 0 54 54"
+      >
+        <title>
+          service speciality logo
+        </title>
+        <g
+          fill="none"
+          id="yld-service-speciality-logo"
+          stroke="none"
+        >
+          <rect
+            fill="black"
+            height="54"
+            id="Logo-rectangle"
+            width="54"
+            x="0"
+            y="0"
+          />
+          <path
+            d="M16.8201464,23.2905974 C18.4977896,23.2905974 19.8575263,21.9304179 19.8575263,20.2527747 C19.8575263,18.5751314 18.4977896,17.2153947 16.8201464,17.2153947 C15.1425032,17.2153947 13.7823237,18.5751314 13.7823237,20.2527747 C13.7823237,21.9304179 15.1425032,23.2905974 16.8201464,23.2905974 L16.8201464,23.2905974 Z M38.4789676,28.2522416 C38.4789676,26.5768122 37.1165743,25.2144189 35.4415877,25.2144189 C33.7666011,25.2144189 32.403765,26.5768122 32.403765,28.2522416 C32.403765,29.9267854 33.7666011,31.2896215 35.4415877,31.2896215 C37.1165743,31.2896215 38.4789676,29.9267854 38.4789676,28.2522416 L38.4789676,28.2522416 Z M42.557735,16 L42.557735,35.1881828 L38.5073047,35.1881828 L38.5073047,34.6325105 C37.5779373,35.0810332 36.5409776,35.339609 35.4415877,35.339609 C31.5332856,35.339609 28.3537775,32.1601009 28.3537775,28.2522416 C28.3537775,24.3434967 31.5332856,21.1639886 35.4415877,21.1639886 C36.5409776,21.1639886 37.5779373,21.4230072 38.5073047,21.8715299 L38.5073047,16 L42.557735,16 Z M28.3537775,16 L28.3537775,28.2522416 L28.3537775,35.1881828 L24.3033473,35.1881828 L24.3033473,23.7931376 L16.8205892,40.632 L12.388494,40.632 L14.6244661,35.6003986 L9,23.2905974 L13.453348,23.2905974 L16.8201464,30.6595644 L20.0948493,23.2905974 L24.3033473,23.2905974 L24.3033473,16 L28.3537775,16 Z"
+            fill="white"
+            id="Logo-fill"
+          />
+        </g>
+      </svg>
+    </a>
+    <a
+      className="c3"
+      color="#1d1d1d"
+      href="/engineering"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+    >
+      Engineering
+    </a>
+  </div>
+  <nav>
+    <ul
+      className="c4"
+    >
+      <li
+        aria-expanded={false}
+        aria-haspopup="true"
+        className="c5"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+      >
+        <span
+          className="c6"
+          tabIndex="0"
+        >
+          <span
+            className="c7"
+          >
+            Dropdown 1
+          </span>
+          <svg
+            className="c8"
+            height="6"
+            viewBox="0 0 6 6"
+            width="6"
+          >
+            <polyline
+              points="0,0 6,0 6,6"
+            />
+          </svg>
+        </span>
+        <ul
+          className="c9"
+        >
+          <li
+            className="c10"
+          >
+            <a
+              className="c11"
+              href="/item-1/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Item 1
+            </a>
+          </li>
+          <li
+            className="c10"
+          >
+            <a
+              className="c11"
+              href="/item-2/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Item 2
+            </a>
+          </li>
+          <li
+            className="c10"
+          >
+            <a
+              className="c11"
+              href="/item-3/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Item 3
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li
+        className="c12"
+      >
+        <a
+          className="c13"
+          href="/anchor/"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          Anchor 1
+        </a>
+      </li>
+      <li
+        className="c12"
+      >
+        <a
+          className="c13"
+          href="https://uk.linkedin.com/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          External anchor
+        </a>
+      </li>
+      <li
+        aria-expanded={false}
+        aria-haspopup="true"
+        className="c5"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+      >
+        <span
+          className="c6"
+          tabIndex="0"
+        >
+          <span
+            className="c7"
+          >
+            Dropdown 2
+          </span>
+          <svg
+            className="c8"
+            height="6"
+            viewBox="0 0 6 6"
+            width="6"
+          >
+            <polyline
+              points="0,0 6,0 6,6"
+            />
+          </svg>
+        </span>
+        <ul
+          className="c9"
+        >
+          <li
+            className="c10"
+          >
+            <a
+              className="c11"
+              href="/go-here/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Go here
+            </a>
+          </li>
+          <li
+            className="c10"
+          >
+            <a
+              className="c11"
+              href="/go-there/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Go there
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li
+        className="c12"
+      >
+        <a
+          className="c13"
+          href="/last-anchor/"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          Anchor 2
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;
+
+exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
+.c3 {
+  height: 3rem;
+  width: 3rem;
+}
+
+.c4 {
+  font-size: 1.625rem;
+  margin-left: 0.75rem;
+  color: #fff;
+}
+
+.c4:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  color: #fff;
+}
+
+.c14 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c14:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c14:active {
+  outline: none;
+}
+
+.c13 {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #090329;
+  color: #fff;
+}
+
+.c13:hover,
+.c13 > a:hover {
+  background: #65FFCD;
+  color: #007f56;
+}
+
+.c13 > a:active {
+  background: #65FFCD;
+  color: #333333;
+}
+
+.c13 > a.active {
+  background: #090329;
+  color: #828282;
+}
+
+.c13 > a.active:active {
+  background: #090329;
+  color: #828282;
+}
+
+.c13 > a.active:hover {
+  background: #3a3553;
+  color: #fff;
+}
+
+.c9 {
+  stroke: currentColor;
+  stroke-width: 0.1875rem;
+  fill: none;
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+  -webkit-transition: -webkit-transform 0s ease 0.1s;
+  -webkit-transition: transform 0s ease 0.1s;
+  transition: transform 0s ease 0.1s;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c12 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+  width: 100%;
+  background: #f9f9f9;
+  color: #828282;
+}
+
+.c12:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c12:active {
+  outline: none;
+}
+
+.c12:hover,
+.c12.active {
+  color: #333333;
+}
+
+.c6 {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  position: relative;
+  cursor: pointer;
+  background: transparent;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
+.c6 > span {
+  background: #090329;
+  color: #fff;
+}
+
+.c6 > span:hover {
+  background: #65FFCD;
+  color: #007f56;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: outline 300ms ease-out;
+  transition: outline 300ms ease-out;
+  z-index: 2;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c7:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c7:active {
+  outline: none;
+}
+
+.c8 {
+  padding-right: 0.375rem;
+  outline: none;
+}
+
+.c10 {
+  position: absolute;
+  width: 10rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  top: 3rem;
+  left: -9999px;
+  opacity: 0;
+  -webkit-transition: opacity 300ms ease;
+  transition: opacity 300ms ease;
+  background: #f9f9f9;
+  z-index: 999;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 1.5rem;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  display: none;
+}
+
+.c0 {
+  background: #090329;
+  width: 100%;
+}
+
+@media screen and (min-width:960px) {
+  .c3 {
+    height: 3.375rem;
+    width: 3.375rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c4 {
+    font-size: 1.875rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c13 {
+    margin-right: 0.375rem;
+  }
+
+  .c13:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c6 {
+    margin-right: 0.375rem;
+  }
+
+  .c6:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media (min-width:29.4375em) {
+  .c1 {
+    padding-left: 2.25rem;
+  }
+}
+
+@media (min-width:34.5625em) {
+  .c1 {
+    padding-left: calc(50% - 240px);
+  }
+}
+
+@media (min-width:43.8125em) {
+  .c1 {
+    padding-left: 0;
+    width: 100%;
+  }
+}
+
+@media (min-width:74.8125em) {
+  .c1 {
+    width: 68.75rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c5 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+    -webkit-flex: 1;
+    -ms-flex: 1;
+    flex: 1;
+    padding: 1.25rem 0rem 1rem;
+    padding-right: 0rem;
+  }
+}
+
+<header
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+    >
+      <a
+        aria-current="page"
+        className="c3"
+        href="/"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        style={Object {}}
+      >
+        <svg
+          viewBox="0 0 54 54"
+        >
+          <title>
+            service speciality logo
+          </title>
+          <g
+            fill="none"
+            id="yld-service-speciality-logo"
+            stroke="none"
+          >
+            <rect
+              fill="#52FFAC"
+              height="54"
+              id="Logo-rectangle"
+              width="54"
+              x="0"
+              y="0"
+            />
+            <path
+              d="M16.8201464,23.2905974 C18.4977896,23.2905974 19.8575263,21.9304179 19.8575263,20.2527747 C19.8575263,18.5751314 18.4977896,17.2153947 16.8201464,17.2153947 C15.1425032,17.2153947 13.7823237,18.5751314 13.7823237,20.2527747 C13.7823237,21.9304179 15.1425032,23.2905974 16.8201464,23.2905974 L16.8201464,23.2905974 Z M38.4789676,28.2522416 C38.4789676,26.5768122 37.1165743,25.2144189 35.4415877,25.2144189 C33.7666011,25.2144189 32.403765,26.5768122 32.403765,28.2522416 C32.403765,29.9267854 33.7666011,31.2896215 35.4415877,31.2896215 C37.1165743,31.2896215 38.4789676,29.9267854 38.4789676,28.2522416 L38.4789676,28.2522416 Z M42.557735,16 L42.557735,35.1881828 L38.5073047,35.1881828 L38.5073047,34.6325105 C37.5779373,35.0810332 36.5409776,35.339609 35.4415877,35.339609 C31.5332856,35.339609 28.3537775,32.1601009 28.3537775,28.2522416 C28.3537775,24.3434967 31.5332856,21.1639886 35.4415877,21.1639886 C36.5409776,21.1639886 37.5779373,21.4230072 38.5073047,21.8715299 L38.5073047,16 L42.557735,16 Z M28.3537775,16 L28.3537775,28.2522416 L28.3537775,35.1881828 L24.3033473,35.1881828 L24.3033473,23.7931376 L16.8205892,40.632 L12.388494,40.632 L14.6244661,35.6003986 L9,23.2905974 L13.453348,23.2905974 L16.8201464,30.6595644 L20.0948493,23.2905974 L24.3033473,23.2905974 L24.3033473,16 L28.3537775,16 Z"
+              fill="#090329"
+              id="Logo-fill"
+            />
+          </g>
+        </svg>
+      </a>
+      <a
+        className="c4"
+        color="#fff"
+        href="/engineering"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+      >
+        Engineering
+      </a>
+    </div>
+    <nav>
+      <ul
+        className="c5"
+      >
+        <li
+          aria-expanded={false}
+          aria-haspopup="true"
+          className="c6"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+        >
+          <span
+            className="c7"
+            tabIndex="0"
+          >
+            <span
+              className="c8"
+            >
+              Dropdown 1
+            </span>
+            <svg
+              className="c9"
+              height="6"
+              viewBox="0 0 6 6"
+              width="6"
+            >
+              <polyline
+                points="0,0 6,0 6,6"
+              />
+            </svg>
+          </span>
+          <ul
+            className="c10"
+          >
+            <li
+              className="c11"
+            >
+              <a
+                className="c12"
+                href="/item-1/"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Item 1
+              </a>
+            </li>
+            <li
+              className="c11"
+            >
+              <a
+                className="c12"
+                href="/item-2/"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Item 2
+              </a>
+            </li>
+            <li
+              className="c11"
+            >
+              <a
+                className="c12"
+                href="/item-3/"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Item 3
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li
+          className="c13"
+        >
+          <a
+            className="c14"
+            href="/anchor/"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Anchor 1
+          </a>
+        </li>
+        <li
+          className="c13"
+        >
+          <a
+            className="c14"
+            href="https://uk.linkedin.com/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            External anchor
+          </a>
+        </li>
+        <li
+          aria-expanded={false}
+          aria-haspopup="true"
+          className="c6"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+        >
+          <span
+            className="c7"
+            tabIndex="0"
+          >
+            <span
+              className="c8"
+            >
+              Dropdown 2
+            </span>
+            <svg
+              className="c9"
+              height="6"
+              viewBox="0 0 6 6"
+              width="6"
+            >
+              <polyline
+                points="0,0 6,0 6,6"
+              />
+            </svg>
+          </span>
+          <ul
+            className="c10"
+          >
+            <li
+              className="c11"
+            >
+              <a
+                className="c12"
+                href="/go-here/"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Go here
+              </a>
+            </li>
+            <li
+              className="c11"
+            >
+              <a
+                className="c12"
+                href="/go-there/"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Go there
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li
+          className="c13"
+        >
+          <a
+            className="c14"
+            href="/last-anchor/"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Anchor 2
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+`;
+
 exports[`Storyshots Header TopNavbar - light theme 1`] = `
 .c4 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6176,7 +6176,7 @@ exports[`Storyshots Header Header itself 1`] = `
   display: flex;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6209,7 +6209,7 @@ exports[`Storyshots Header Header itself 1`] = `
   flex-basis: 100%;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6233,11 +6233,11 @@ exports[`Storyshots Header Header itself 1`] = `
   justify-content: flex-end;
 }
 
-.c19 {
+.c18 {
   fill: #333333;
 }
 
-.c18 {
+.c17 {
   border: none;
   background: transparent;
   padding: 0;
@@ -6256,36 +6256,11 @@ exports[`Storyshots Header Header itself 1`] = `
   -ms-flex-align: center;
   align-items: center;
   position: absolute;
+  right: 0;
   top: 0;
   width: 5rem;
   height: 5rem;
-  right: 1.5rem;
   margin: 0.25rem -1.25rem 0.25rem 0.25rem;
-  outline: 0.25rem solid transparent;
-}
-
-.c18:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c18:active {
-  outline: none;
-}
-
-.c20 {
-  display: none;
-}
-
-.c17 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
-  background: linear-gradient(to right,#616161 0%,transparent 0);
-  outline: none;
-  font-weight: 400;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
-  padding: 0.625rem 0.9375rem 0.875rem;
   outline: 0.25rem solid transparent;
 }
 
@@ -6298,7 +6273,32 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: none;
 }
 
+.c19 {
+  display: none;
+}
+
 .c16 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c16:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c16:active {
+  outline: none;
+}
+
+.c15 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   display: -webkit-box;
   display: -webkit-flex;
@@ -6308,32 +6308,32 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #333333;
 }
 
-.c16:hover,
-.c16 > a:hover {
+.c15:hover,
+.c15 > a:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c16 > a:active {
+.c15 > a:active {
   background: #333333;
   color: #fff;
 }
 
-.c16 > a.active {
+.c15 > a.active {
   background: #fff;
   color: #828282;
 }
 
-.c16 > a.active:active {
+.c15 > a.active:active {
   background: #fff;
   color: #828282;
 }
 
-.c16 > a.active:hover {
+.c15 > a.active:hover {
   color: #333333;
 }
 
-.c12 {
+.c11 {
   stroke: currentColor;
   stroke-width: 0.1875rem;
   fill: none;
@@ -6345,14 +6345,14 @@ exports[`Storyshots Header Header itself 1`] = `
   transition: transform 0s ease 0.1s;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c15 {
+.c14 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
@@ -6367,21 +6367,21 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #828282;
 }
 
-.c15:focus {
+.c14:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c15:active {
+.c14:active {
   outline: none;
 }
 
-.c15:hover,
-.c15.active {
+.c14:hover,
+.c14.active {
   color: #333333;
 }
 
-.c9 {
+.c8 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   position: relative;
   cursor: pointer;
@@ -6389,17 +6389,17 @@ exports[`Storyshots Header Header itself 1`] = `
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
-.c9 > span {
+.c8 > span {
   background: #fff;
   color: #333333;
 }
 
-.c9 > span:hover {
+.c8 > span:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6422,21 +6422,21 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
 }
 
-.c10:focus {
+.c9:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c10:active {
+.c9:active {
   outline: none;
 }
 
-.c11 {
+.c10 {
   padding-right: 0.375rem;
   outline: none;
 }
 
-.c13 {
+.c12 {
   position: absolute;
   width: 10rem;
   display: -webkit-box;
@@ -6455,7 +6455,7 @@ exports[`Storyshots Header Header itself 1`] = `
   z-index: 999;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6464,10 +6464,11 @@ exports[`Storyshots Header Header itself 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding-left: 1.5rem;
+  width: 100%;
+  height: 5.25rem;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6478,11 +6479,11 @@ exports[`Storyshots Header Header itself 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: none;
 }
 
-.c23 {
+.c22 {
   border: none;
   background: transparent;
   padding: 0;
@@ -6506,16 +6507,16 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
 }
 
-.c23:focus {
+.c22:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c23:active {
+.c22:active {
   outline: none;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6538,28 +6539,28 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #858196;
 }
 
-.c26:focus {
+.c25:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c26:active {
+.c25:active {
   outline: none;
 }
 
-.c26:hover,
-.c26:focus {
+.c25:hover,
+.c25:focus {
   color: #fff;
 }
 
-.c27 {
+.c26 {
   max-width: 320px;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c25 {
+.c24 {
   display: block;
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
@@ -6573,31 +6574,31 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #858196;
 }
 
-.c25:hover,
-.c25:active,
-.c25.active {
+.c24:hover,
+.c24:active,
+.c24.active {
   color: #fff;
 }
 
-.c25:focus {
+.c24:focus {
   color: #fff;
   outline: 0.25rem solid transparent;
 }
 
-.c25:focus:focus {
+.c24:focus:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c25:focus:active {
+.c24:focus:active {
   outline: none;
 }
 
-.c24 {
+.c23 {
   list-style-type: none;
 }
 
-.c21 {
+.c20 {
   position: fixed;
   background: #090329;
   height: 100vh;
@@ -6613,14 +6614,8 @@ exports[`Storyshots Header Header itself 1`] = `
   transition: transform 200ms ease-in-out;
 }
 
-.c4 {
-  padding-bottom: 2.25rem;
-  height: 7.5rem;
-}
-
 .c0 {
   position: fixed;
-  height: 5.25rem;
   background: #fff;
   width: 100%;
   max-width: unset;
@@ -6756,32 +6751,14 @@ exports[`Storyshots Header Header itself 1`] = `
   }
 }
 
-@media (min-width:29.4375em) {
-  .c18 {
-    right: 2.25rem;
-  }
-}
-
-@media (min-width:34.5625em) {
-  .c18 {
-    right: calc(50% - 240px);
-  }
-}
-
-@media (min-width:43.8125em) {
-  .c18 {
-    right: 0;
-  }
-}
-
 @media screen and (min-width:960px) {
-  .c18 {
+  .c17 {
     display: none;
   }
 }
 
 @media screen and (max-width:959px) {
-  .c20 {
+  .c19 {
     z-index: 9;
     background-color: rgba(51,51,51,0.2);
     content: '';
@@ -6801,52 +6778,27 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c16 {
+  .c15 {
     margin-right: 0.375rem;
   }
 
-  .c16:last-child {
+  .c15:last-child {
     margin-right: 0rem;
-  }
-}
-
-@media screen and (min-width:960px) {
-  .c9 {
-    margin-right: 0.375rem;
-  }
-
-  .c9:last-child {
-    margin-right: 0rem;
-  }
-}
-
-@media (min-width:29.4375em) {
-  .c6 {
-    padding-left: 2.25rem;
-  }
-}
-
-@media (min-width:34.5625em) {
-  .c6 {
-    padding-left: calc(50% - 240px);
-  }
-}
-
-@media (min-width:43.8125em) {
-  .c6 {
-    padding-left: 0;
-    width: 100%;
-  }
-}
-
-@media (min-width:74.8125em) {
-  .c6 {
-    width: 68.75rem;
   }
 }
 
 @media screen and (min-width:960px) {
   .c8 {
+    margin-right: 0.375rem;
+  }
+
+  .c8:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c7 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -6858,16 +6810,13 @@ exports[`Storyshots Header Header itself 1`] = `
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
     justify-content: space-between;
-    -webkit-flex: 1;
-    -ms-flex: 1;
-    flex: 1;
     padding: 1.25rem 0rem 1rem;
     padding-right: 0rem;
   }
 }
 
 @media screen and (min-width:600px) and (max-width:959px) {
-  .c21 {
+  .c20 {
     width: 18.4375rem;
     left: auto;
     right: 0;
@@ -6875,59 +6824,46 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c21 {
+  .c20 {
     display: none;
   }
 }
 
-@media (min-width:74.8125em) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-pack: center;
-    -webkit-justify-content: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-  }
-}
-
 <div
-  className="c0 c1"
+  className="c0"
 >
   <div
-    className="c2"
-    style={
-      Object {
-        "overflow": "visible",
-      }
-    }
+    className="c1"
   >
     <div
-      className="c3"
+      className="c2"
       style={
         Object {
           "overflow": "visible",
         }
       }
-      width={
-        Array [
-          1,
-        ]
-      }
     >
       <div
-        className="c4"
+        className="c3"
+        style={
+          Object {
+            "overflow": "visible",
+          }
+        }
+        width={
+          Array [
+            1,
+          ]
+        }
       >
         <header
-          className="c5"
+          className="c4"
         >
-          <div
-            className="c6"
+          <nav
+            className="c5"
           >
             <div
-              className="c7"
+              className="c6"
             >
               <a
                 aria-current="page"
@@ -6945,188 +6881,186 @@ exports[`Storyshots Header Header itself 1`] = `
                 />
               </a>
             </div>
-            <nav>
-              <ul
+            <ul
+              className="c7"
+            >
+              <li
+                aria-expanded={false}
+                aria-haspopup="true"
                 className="c8"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
               >
-                <li
-                  aria-expanded={false}
-                  aria-haspopup="true"
+                <span
                   className="c9"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseDown={[Function]}
+                  tabIndex="0"
                 >
                   <span
                     className="c10"
-                    tabIndex="0"
                   >
-                    <span
-                      className="c11"
-                    >
-                      Services
-                    </span>
-                    <svg
-                      className="c12"
-                      height="6"
-                      viewBox="0 0 6 6"
-                      width="6"
-                    >
-                      <polyline
-                        points="0,0 6,0 6,6"
-                      />
-                    </svg>
+                    Services
                   </span>
-                  <ul
+                  <svg
+                    className="c11"
+                    height="6"
+                    viewBox="0 0 6 6"
+                    width="6"
+                  >
+                    <polyline
+                      points="0,0 6,0 6,6"
+                    />
+                  </svg>
+                </span>
+                <ul
+                  className="c12"
+                >
+                  <li
                     className="c13"
                   >
-                    <li
+                    <a
                       className="c14"
+                      href="/engineering/"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
                     >
-                      <a
-                        className="c15"
-                        href="/engineering/"
-                        onClick={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        Engineering
-                      </a>
-                    </li>
-                    <li
-                      className="c14"
-                    >
-                      <a
-                        className="c15"
-                        href="/design/"
-                        onClick={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        Design
-                      </a>
-                    </li>
-                    <li
-                      className="c14"
-                    >
-                      <a
-                        className="c15"
-                        href="/training/"
-                        onClick={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        Training
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-                <li
-                  className="c16"
-                >
-                  <a
-                    className="c17"
-                    href="/our-work/"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
+                      Engineering
+                    </a>
+                  </li>
+                  <li
+                    className="c13"
                   >
-                    Our work
-                  </a>
-                </li>
-                <li
-                  className="c16"
-                >
-                  <a
-                    className="c17"
-                    href="https://medium.com/yld-engineering-blog/"
-                    rel="noopener noreferrer"
-                    target="_blank"
+                    <a
+                      className="c14"
+                      href="/design/"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                    >
+                      Design
+                    </a>
+                  </li>
+                  <li
+                    className="c13"
                   >
-                    Blog
-                  </a>
-                </li>
-                <li
-                  aria-expanded={false}
-                  aria-haspopup="true"
-                  className="c9"
-                  onBlur={[Function]}
+                    <a
+                      className="c14"
+                      href="/training/"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                    >
+                      Training
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="c15"
+              >
+                <a
+                  className="c16"
+                  href="/our-work/"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  Our work
+                </a>
+              </li>
+              <li
+                className="c15"
+              >
+                <a
+                  className="c16"
+                  href="https://medium.com/yld-engineering-blog/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Blog
+                </a>
+              </li>
+              <li
+                aria-expanded={false}
+                aria-haspopup="true"
+                className="c8"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
+              >
+                <span
+                  className="c9"
+                  tabIndex="0"
                 >
                   <span
                     className="c10"
-                    tabIndex="0"
                   >
-                    <span
-                      className="c11"
-                    >
-                      About
-                    </span>
-                    <svg
-                      className="c12"
-                      height="6"
-                      viewBox="0 0 6 6"
-                      width="6"
-                    >
-                      <polyline
-                        points="0,0 6,0 6,6"
-                      />
-                    </svg>
+                    About
                   </span>
-                  <ul
+                  <svg
+                    className="c11"
+                    height="6"
+                    viewBox="0 0 6 6"
+                    width="6"
+                  >
+                    <polyline
+                      points="0,0 6,0 6,6"
+                    />
+                  </svg>
+                </span>
+                <ul
+                  className="c12"
+                >
+                  <li
                     className="c13"
                   >
-                    <li
+                    <a
                       className="c14"
+                      href="/about-us/"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
                     >
-                      <a
-                        className="c15"
-                        href="/about-us/"
-                        onClick={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        Our team
-                      </a>
-                    </li>
-                    <li
-                      className="c14"
-                    >
-                      <a
-                        className="c15"
-                        href="/contact/"
-                        onClick={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseEnter={[Function]}
-                      >
-                        Contact
-                      </a>
-                    </li>
-                  </ul>
-                </li>
-                <li
-                  className="c16"
-                >
-                  <a
-                    className="c17"
-                    href="/join-us/"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
+                      Our team
+                    </a>
+                  </li>
+                  <li
+                    className="c13"
                   >
-                    Join us
-                  </a>
-                </li>
-              </ul>
-            </nav>
-          </div>
+                    <a
+                      className="c14"
+                      href="/contact/"
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                    >
+                      Contact
+                    </a>
+                  </li>
+                </ul>
+              </li>
+              <li
+                className="c15"
+              >
+                <a
+                  className="c16"
+                  href="/join-us/"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                >
+                  Join us
+                </a>
+              </li>
+            </ul>
+          </nav>
           <button
-            className="c18"
+            className="c17"
             onClick={[Function]}
           >
             <svg
-              className="c19"
+              className="c18"
               height="18"
               title="open menu"
               width="24"
@@ -7139,18 +7073,18 @@ exports[`Storyshots Header Header itself 1`] = `
             </svg>
           </button>
           <div
-            className="c20"
+            className="c19"
             onClick={[Function]}
           />
           <nav
-            className="c21"
+            className="c20"
             open={false}
           >
             <div
-              className="c22"
+              className="c21"
             >
               <button
-                className="c23"
+                className="c22"
                 onClick={[Function]}
               >
                 <img
@@ -7161,11 +7095,11 @@ exports[`Storyshots Header Header itself 1`] = `
             </div>
             <ul>
               <li
-                className="c24"
+                className="c23"
               >
                 <a
                   aria-current="page"
-                  className="c25 active"
+                  className="c24 active"
                   href="/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -7195,18 +7129,18 @@ exports[`Storyshots Header Header itself 1`] = `
                 aria-haspopup="true"
               >
                 <span
-                  className="c26"
+                  className="c25"
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   tabIndex="0"
                 >
                   <span
-                    className="c27"
+                    className="c26"
                   >
                     Services
                   </span>
                   <svg
-                    className="c12"
+                    className="c11"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -7218,10 +7152,10 @@ exports[`Storyshots Header Header itself 1`] = `
                 </span>
               </li>
               <li
-                className="c24"
+                className="c23"
               >
                 <a
-                  className="c25"
+                  className="c24"
                   href="/our-work/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -7246,10 +7180,10 @@ exports[`Storyshots Header Header itself 1`] = `
                 </a>
               </li>
               <li
-                className="c24"
+                className="c23"
               >
                 <a
-                  className="c25"
+                  className="c24"
                   href="https://medium.com/yld-engineering-blog/"
                   rel="noopener noreferrer"
                   states={
@@ -7278,18 +7212,18 @@ exports[`Storyshots Header Header itself 1`] = `
                 aria-haspopup="true"
               >
                 <span
-                  className="c26"
+                  className="c25"
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   tabIndex="0"
                 >
                   <span
-                    className="c27"
+                    className="c26"
                   >
                     About
                   </span>
                   <svg
-                    className="c12"
+                    className="c11"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -7301,10 +7235,10 @@ exports[`Storyshots Header Header itself 1`] = `
                 </span>
               </li>
               <li
-                className="c24"
+                className="c23"
               >
                 <a
-                  className="c25"
+                  className="c24"
                   href="/join-us/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -7542,7 +7476,8 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding-left: 1.5rem;
+  width: 100%;
+  height: 5.25rem;
 }
 
 .c1 {
@@ -7593,31 +7528,6 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
   }
 }
 
-@media (min-width:29.4375em) {
-  .c0 {
-    padding-left: 2.25rem;
-  }
-}
-
-@media (min-width:34.5625em) {
-  .c0 {
-    padding-left: calc(50% - 240px);
-  }
-}
-
-@media (min-width:43.8125em) {
-  .c0 {
-    padding-left: 0;
-    width: 100%;
-  }
-}
-
-@media (min-width:74.8125em) {
-  .c0 {
-    width: 68.75rem;
-  }
-}
-
 @media screen and (min-width:960px) {
   .c4 {
     display: -webkit-box;
@@ -7631,15 +7541,12 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
     justify-content: space-between;
-    -webkit-flex: 1;
-    -ms-flex: 1;
-    flex: 1;
     padding: 1.25rem 0rem 1rem;
     padding-right: 0rem;
   }
 }
 
-<div
+<nav
   className="c0"
 >
   <div
@@ -7691,182 +7598,180 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
       Engineering
     </a>
   </div>
-  <nav>
-    <ul
-      className="c4"
+  <ul
+    className="c4"
+  >
+    <li
+      aria-expanded={false}
+      aria-haspopup="true"
+      className="c5"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
     >
-      <li
-        aria-expanded={false}
-        aria-haspopup="true"
-        className="c5"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
+      <span
+        className="c6"
+        tabIndex="0"
       >
         <span
-          className="c6"
-          tabIndex="0"
+          className="c7"
         >
-          <span
-            className="c7"
-          >
-            Dropdown 1
-          </span>
-          <svg
-            className="c8"
-            height="6"
-            viewBox="0 0 6 6"
-            width="6"
-          >
-            <polyline
-              points="0,0 6,0 6,6"
-            />
-          </svg>
+          Dropdown 1
         </span>
-        <ul
-          className="c9"
+        <svg
+          className="c8"
+          height="6"
+          viewBox="0 0 6 6"
+          width="6"
         >
-          <li
-            className="c10"
-          >
-            <a
-              className="c11"
-              href="/item-1/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Item 1
-            </a>
-          </li>
-          <li
-            className="c10"
-          >
-            <a
-              className="c11"
-              href="/item-2/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Item 2
-            </a>
-          </li>
-          <li
-            className="c10"
-          >
-            <a
-              className="c11"
-              href="/item-3/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Item 3
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li
-        className="c12"
+          <polyline
+            points="0,0 6,0 6,6"
+          />
+        </svg>
+      </span>
+      <ul
+        className="c9"
       >
-        <a
-          className="c13"
-          href="/anchor/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
+        <li
+          className="c10"
         >
-          Anchor 1
-        </a>
-      </li>
-      <li
-        className="c12"
-      >
-        <a
-          className="c13"
-          href="https://uk.linkedin.com/"
-          rel="noopener noreferrer"
-          target="_blank"
+          <a
+            className="c11"
+            href="/item-1/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Item 1
+          </a>
+        </li>
+        <li
+          className="c10"
         >
-          External anchor
-        </a>
-      </li>
-      <li
-        aria-expanded={false}
-        aria-haspopup="true"
-        className="c5"
-        onBlur={[Function]}
+          <a
+            className="c11"
+            href="/item-2/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Item 2
+          </a>
+        </li>
+        <li
+          className="c10"
+        >
+          <a
+            className="c11"
+            href="/item-3/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Item 3
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      className="c12"
+    >
+      <a
+        className="c13"
+        href="/anchor/"
         onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+      >
+        Anchor 1
+      </a>
+    </li>
+    <li
+      className="c12"
+    >
+      <a
+        className="c13"
+        href="https://uk.linkedin.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        External anchor
+      </a>
+    </li>
+    <li
+      aria-expanded={false}
+      aria-haspopup="true"
+      className="c5"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="c6"
+        tabIndex="0"
       >
         <span
-          className="c6"
-          tabIndex="0"
+          className="c7"
         >
-          <span
-            className="c7"
-          >
-            Dropdown 2
-          </span>
-          <svg
-            className="c8"
-            height="6"
-            viewBox="0 0 6 6"
-            width="6"
-          >
-            <polyline
-              points="0,0 6,0 6,6"
-            />
-          </svg>
+          Dropdown 2
         </span>
-        <ul
-          className="c9"
+        <svg
+          className="c8"
+          height="6"
+          viewBox="0 0 6 6"
+          width="6"
         >
-          <li
-            className="c10"
-          >
-            <a
-              className="c11"
-              href="/go-here/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Go here
-            </a>
-          </li>
-          <li
-            className="c10"
-          >
-            <a
-              className="c11"
-              href="/go-there/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Go there
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li
-        className="c12"
+          <polyline
+            points="0,0 6,0 6,6"
+          />
+        </svg>
+      </span>
+      <ul
+        className="c9"
       >
-        <a
-          className="c13"
-          href="/last-anchor/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
+        <li
+          className="c10"
         >
-          Anchor 2
-        </a>
-      </li>
-    </ul>
-  </nav>
-</div>
+          <a
+            className="c11"
+            href="/go-here/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Go here
+          </a>
+        </li>
+        <li
+          className="c10"
+        >
+          <a
+            className="c11"
+            href="/go-there/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Go there
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      className="c12"
+    >
+      <a
+        className="c13"
+        href="/last-anchor/"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+      >
+        Anchor 2
+      </a>
+    </li>
+  </ul>
+</nav>
 `;
 
 exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
@@ -8075,7 +7980,8 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding-left: 1.5rem;
+  width: 100%;
+  height: 5.25rem;
 }
 
 .c2 {
@@ -8131,31 +8037,6 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
   }
 }
 
-@media (min-width:29.4375em) {
-  .c1 {
-    padding-left: 2.25rem;
-  }
-}
-
-@media (min-width:34.5625em) {
-  .c1 {
-    padding-left: calc(50% - 240px);
-  }
-}
-
-@media (min-width:43.8125em) {
-  .c1 {
-    padding-left: 0;
-    width: 100%;
-  }
-}
-
-@media (min-width:74.8125em) {
-  .c1 {
-    width: 68.75rem;
-  }
-}
-
 @media screen and (min-width:960px) {
   .c5 {
     display: -webkit-box;
@@ -8169,9 +8050,6 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
     justify-content: space-between;
-    -webkit-flex: 1;
-    -ms-flex: 1;
-    flex: 1;
     padding: 1.25rem 0rem 1rem;
     padding-right: 0rem;
   }
@@ -8180,7 +8058,7 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
 <header
   className="c0"
 >
-  <div
+  <nav
     className="c1"
   >
     <div
@@ -8232,182 +8110,180 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
         Engineering
       </a>
     </div>
-    <nav>
-      <ul
-        className="c5"
+    <ul
+      className="c5"
+    >
+      <li
+        aria-expanded={false}
+        aria-haspopup="true"
+        className="c6"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
       >
-        <li
-          aria-expanded={false}
-          aria-haspopup="true"
-          className="c6"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
+        <span
+          className="c7"
+          tabIndex="0"
         >
           <span
-            className="c7"
-            tabIndex="0"
+            className="c8"
           >
-            <span
-              className="c8"
-            >
-              Dropdown 1
-            </span>
-            <svg
-              className="c9"
-              height="6"
-              viewBox="0 0 6 6"
-              width="6"
-            >
-              <polyline
-                points="0,0 6,0 6,6"
-              />
-            </svg>
+            Dropdown 1
           </span>
-          <ul
-            className="c10"
+          <svg
+            className="c9"
+            height="6"
+            viewBox="0 0 6 6"
+            width="6"
           >
-            <li
-              className="c11"
-            >
-              <a
-                className="c12"
-                href="/item-1/"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-              >
-                Item 1
-              </a>
-            </li>
-            <li
-              className="c11"
-            >
-              <a
-                className="c12"
-                href="/item-2/"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-              >
-                Item 2
-              </a>
-            </li>
-            <li
-              className="c11"
-            >
-              <a
-                className="c12"
-                href="/item-3/"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-              >
-                Item 3
-              </a>
-            </li>
-          </ul>
-        </li>
-        <li
-          className="c13"
+            <polyline
+              points="0,0 6,0 6,6"
+            />
+          </svg>
+        </span>
+        <ul
+          className="c10"
         >
-          <a
-            className="c14"
-            href="/anchor/"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
+          <li
+            className="c11"
           >
-            Anchor 1
-          </a>
-        </li>
-        <li
-          className="c13"
-        >
-          <a
-            className="c14"
-            href="https://uk.linkedin.com/"
-            rel="noopener noreferrer"
-            target="_blank"
+            <a
+              className="c12"
+              href="/item-1/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Item 1
+            </a>
+          </li>
+          <li
+            className="c11"
           >
-            External anchor
-          </a>
-        </li>
-        <li
-          aria-expanded={false}
-          aria-haspopup="true"
-          className="c6"
-          onBlur={[Function]}
+            <a
+              className="c12"
+              href="/item-2/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Item 2
+            </a>
+          </li>
+          <li
+            className="c11"
+          >
+            <a
+              className="c12"
+              href="/item-3/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Item 3
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li
+        className="c13"
+      >
+        <a
+          className="c14"
+          href="/anchor/"
           onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+        >
+          Anchor 1
+        </a>
+      </li>
+      <li
+        className="c13"
+      >
+        <a
+          className="c14"
+          href="https://uk.linkedin.com/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          External anchor
+        </a>
+      </li>
+      <li
+        aria-expanded={false}
+        aria-haspopup="true"
+        className="c6"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+      >
+        <span
+          className="c7"
+          tabIndex="0"
         >
           <span
-            className="c7"
-            tabIndex="0"
+            className="c8"
           >
-            <span
-              className="c8"
-            >
-              Dropdown 2
-            </span>
-            <svg
-              className="c9"
-              height="6"
-              viewBox="0 0 6 6"
-              width="6"
-            >
-              <polyline
-                points="0,0 6,0 6,6"
-              />
-            </svg>
+            Dropdown 2
           </span>
-          <ul
-            className="c10"
+          <svg
+            className="c9"
+            height="6"
+            viewBox="0 0 6 6"
+            width="6"
           >
-            <li
-              className="c11"
-            >
-              <a
-                className="c12"
-                href="/go-here/"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-              >
-                Go here
-              </a>
-            </li>
-            <li
-              className="c11"
-            >
-              <a
-                className="c12"
-                href="/go-there/"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-              >
-                Go there
-              </a>
-            </li>
-          </ul>
-        </li>
-        <li
-          className="c13"
+            <polyline
+              points="0,0 6,0 6,6"
+            />
+          </svg>
+        </span>
+        <ul
+          className="c10"
         >
-          <a
-            className="c14"
-            href="/last-anchor/"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
+          <li
+            className="c11"
           >
-            Anchor 2
-          </a>
-        </li>
-      </ul>
-    </nav>
-  </div>
+            <a
+              className="c12"
+              href="/go-here/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Go here
+            </a>
+          </li>
+          <li
+            className="c11"
+          >
+            <a
+              className="c12"
+              href="/go-there/"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+            >
+              Go there
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li
+        className="c13"
+      >
+        <a
+          className="c14"
+          href="/last-anchor/"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          Anchor 2
+        </a>
+      </li>
+    </ul>
+  </nav>
 </header>
 `;
 
@@ -8477,7 +8353,8 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding-left: 1.5rem;
+  width: 100%;
+  height: 5.25rem;
 }
 
 .c1 {
@@ -8505,31 +8382,6 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
   }
 }
 
-@media (min-width:29.4375em) {
-  .c0 {
-    padding-left: 2.25rem;
-  }
-}
-
-@media (min-width:34.5625em) {
-  .c0 {
-    padding-left: calc(50% - 240px);
-  }
-}
-
-@media (min-width:43.8125em) {
-  .c0 {
-    padding-left: 0;
-    width: 100%;
-  }
-}
-
-@media (min-width:74.8125em) {
-  .c0 {
-    width: 68.75rem;
-  }
-}
-
 @media screen and (min-width:960px) {
   .c2 {
     display: -webkit-box;
@@ -8543,15 +8395,12 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
     justify-content: space-between;
-    -webkit-flex: 1;
-    -ms-flex: 1;
-    flex: 1;
     padding: 1.25rem 0rem 1rem;
     padding-right: 0rem;
   }
 }
 
-<div
+<nav
   className="c0"
 >
   <div
@@ -8573,51 +8422,49 @@ exports[`Storyshots Header TopNavbar - light theme 1`] = `
       />
     </a>
   </div>
-  <nav>
-    <ul
-      className="c2"
+  <ul
+    className="c2"
+  >
+    <li
+      className="c3"
     >
-      <li
-        className="c3"
+      <a
+        aria-current="page"
+        className="c4 active"
+        href="/"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        style={Object {}}
       >
-        <a
-          aria-current="page"
-          className="c4 active"
-          href="/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
-          style={Object {}}
-        >
-          Here
-        </a>
-      </li>
-      <li
-        className="c3"
+        Here
+      </a>
+    </li>
+    <li
+      className="c3"
+    >
+      <a
+        className="c4"
+        href="/there"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
       >
-        <a
-          className="c4"
-          href="/there"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
-        >
-          There
-        </a>
-      </li>
-      <li
-        className="c3"
+        There
+      </a>
+    </li>
+    <li
+      className="c3"
+    >
+      <a
+        className="c4"
+        href="/https:/uk.linkedin.com/"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
       >
-        <a
-          className="c4"
-          href="/https:/uk.linkedin.com/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
-        >
-          LinkedIn (external anchor)
-        </a>
-      </li>
-    </ul>
-  </nav>
-</div>
+        LinkedIn (external anchor)
+      </a>
+    </li>
+  </ul>
+</nav>
 `;
 
 exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
@@ -8808,7 +8655,8 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  padding-left: 1.5rem;
+  width: 100%;
+  height: 5.25rem;
 }
 
 .c1 {
@@ -8846,31 +8694,6 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
   }
 }
 
-@media (min-width:29.4375em) {
-  .c0 {
-    padding-left: 2.25rem;
-  }
-}
-
-@media (min-width:34.5625em) {
-  .c0 {
-    padding-left: calc(50% - 240px);
-  }
-}
-
-@media (min-width:43.8125em) {
-  .c0 {
-    padding-left: 0;
-    width: 100%;
-  }
-}
-
-@media (min-width:74.8125em) {
-  .c0 {
-    width: 68.75rem;
-  }
-}
-
 @media screen and (min-width:960px) {
   .c2 {
     display: -webkit-box;
@@ -8884,15 +8707,12 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
     -webkit-justify-content: space-between;
     -ms-flex-pack: justify;
     justify-content: space-between;
-    -webkit-flex: 1;
-    -ms-flex: 1;
-    flex: 1;
     padding: 1.25rem 0rem 1rem;
     padding-right: 0rem;
   }
 }
 
-<div
+<nav
   className="c0"
 >
   <div
@@ -8914,182 +8734,180 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
       />
     </a>
   </div>
-  <nav>
-    <ul
-      className="c2"
+  <ul
+    className="c2"
+  >
+    <li
+      aria-expanded={false}
+      aria-haspopup="true"
+      className="c3"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
     >
-      <li
-        aria-expanded={false}
-        aria-haspopup="true"
-        className="c3"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
+      <span
+        className="c4"
+        tabIndex="0"
       >
         <span
-          className="c4"
-          tabIndex="0"
+          className="c5"
         >
-          <span
-            className="c5"
-          >
-            First dropdown
-          </span>
-          <svg
-            className="c6"
-            height="6"
-            viewBox="0 0 6 6"
-            width="6"
-          >
-            <polyline
-              points="0,0 6,0 6,6"
-            />
-          </svg>
+          First dropdown
         </span>
-        <ul
-          className="c7"
+        <svg
+          className="c6"
+          height="6"
+          viewBox="0 0 6 6"
+          width="6"
         >
-          <li
-            className="c8"
-          >
-            <a
-              className="c9"
-              href="/item-1/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Item 1
-            </a>
-          </li>
-          <li
-            className="c8"
-          >
-            <a
-              className="c9"
-              href="/item-2/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Item 2
-            </a>
-          </li>
-          <li
-            className="c8"
-          >
-            <a
-              className="c9"
-              href="/item-3/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Item 3
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li
-        className="c10"
+          <polyline
+            points="0,0 6,0 6,6"
+          />
+        </svg>
+      </span>
+      <ul
+        className="c7"
       >
-        <a
-          className="c11"
-          href="/anchor/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
+        <li
+          className="c8"
         >
-          First anchor
-        </a>
-      </li>
-      <li
-        className="c10"
-      >
-        <a
-          className="c11"
-          href="https://uk.linkedin.com/"
-          rel="noopener noreferrer"
-          target="_blank"
+          <a
+            className="c9"
+            href="/item-1/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Item 1
+          </a>
+        </li>
+        <li
+          className="c8"
         >
-          LinkedIn (external anchor)
-        </a>
-      </li>
-      <li
-        aria-expanded={false}
-        aria-haspopup="true"
-        className="c3"
-        onBlur={[Function]}
+          <a
+            className="c9"
+            href="/item-2/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Item 2
+          </a>
+        </li>
+        <li
+          className="c8"
+        >
+          <a
+            className="c9"
+            href="/item-3/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Item 3
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      className="c10"
+    >
+      <a
+        className="c11"
+        href="/anchor/"
         onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+      >
+        First anchor
+      </a>
+    </li>
+    <li
+      className="c10"
+    >
+      <a
+        className="c11"
+        href="https://uk.linkedin.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        LinkedIn (external anchor)
+      </a>
+    </li>
+    <li
+      aria-expanded={false}
+      aria-haspopup="true"
+      className="c3"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+    >
+      <span
+        className="c4"
+        tabIndex="0"
       >
         <span
-          className="c4"
-          tabIndex="0"
+          className="c5"
         >
-          <span
-            className="c5"
-          >
-            Second dropdown
-          </span>
-          <svg
-            className="c6"
-            height="6"
-            viewBox="0 0 6 6"
-            width="6"
-          >
-            <polyline
-              points="0,0 6,0 6,6"
-            />
-          </svg>
+          Second dropdown
         </span>
-        <ul
-          className="c7"
+        <svg
+          className="c6"
+          height="6"
+          viewBox="0 0 6 6"
+          width="6"
         >
-          <li
-            className="c8"
-          >
-            <a
-              className="c9"
-              href="/go-here/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Go here
-            </a>
-          </li>
-          <li
-            className="c8"
-          >
-            <a
-              className="c9"
-              href="/go-there/"
-              onClick={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Go there
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li
-        className="c10"
+          <polyline
+            points="0,0 6,0 6,6"
+          />
+        </svg>
+      </span>
+      <ul
+        className="c7"
       >
-        <a
-          className="c11"
-          href="/last-anchor/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
+        <li
+          className="c8"
         >
-          Last anchor
-        </a>
-      </li>
-    </ul>
-  </nav>
-</div>
+          <a
+            className="c9"
+            href="/go-here/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Go here
+          </a>
+        </li>
+        <li
+          className="c8"
+        >
+          <a
+            className="c9"
+            href="/go-there/"
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+          >
+            Go there
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li
+      className="c10"
+    >
+      <a
+        className="c11"
+        href="/last-anchor/"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+      >
+        Last anchor
+      </a>
+    </li>
+  </ul>
+</nav>
 `;
 
 exports[`Storyshots Image with file url 1`] = `

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6176,68 +6176,11 @@ exports[`Storyshots Header Header itself 1`] = `
   display: flex;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c18 {
+.c17 {
   fill: #333333;
 }
 
-.c17 {
+.c16 {
   border: none;
   background: transparent;
   padding: 0;
@@ -6264,20 +6207,20 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
 }
 
-.c17:focus {
+.c16:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c17:active {
+.c16:active {
   outline: none;
 }
 
-.c19 {
+.c18 {
   display: none;
 }
 
-.c16 {
+.c15 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
@@ -6289,16 +6232,16 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
 }
 
-.c16:focus {
+.c15:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c16:active {
+.c15:active {
   outline: none;
 }
 
-.c15 {
+.c14 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   display: -webkit-box;
   display: -webkit-flex;
@@ -6308,32 +6251,32 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #333333;
 }
 
-.c15:hover,
-.c15 > a:hover {
+.c14:hover,
+.c14 > a:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c15 > a:active {
+.c14 > a:active {
   background: #333333;
   color: #fff;
 }
 
-.c15 > a.active {
+.c14 > a.active {
   background: #fff;
   color: #828282;
 }
 
-.c15 > a.active:active {
+.c14 > a.active:active {
   background: #fff;
   color: #828282;
 }
 
-.c15 > a.active:hover {
+.c14 > a.active:hover {
   color: #333333;
 }
 
-.c11 {
+.c10 {
   stroke: currentColor;
   stroke-width: 0.1875rem;
   fill: none;
@@ -6345,14 +6288,14 @@ exports[`Storyshots Header Header itself 1`] = `
   transition: transform 0s ease 0.1s;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
@@ -6367,21 +6310,21 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #828282;
 }
 
-.c14:focus {
+.c13:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c14:active {
+.c13:active {
   outline: none;
 }
 
-.c14:hover,
-.c14.active {
+.c13:hover,
+.c13.active {
   color: #333333;
 }
 
-.c8 {
+.c7 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   position: relative;
   cursor: pointer;
@@ -6389,17 +6332,17 @@ exports[`Storyshots Header Header itself 1`] = `
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
-.c8 > span {
+.c7 > span {
   background: #fff;
   color: #333333;
 }
 
-.c8 > span:hover {
+.c7 > span:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6422,21 +6365,21 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
 }
 
-.c9:focus {
+.c8:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c9:active {
+.c8:active {
   outline: none;
 }
 
-.c10 {
+.c9 {
   padding-right: 0.375rem;
   outline: none;
 }
 
-.c12 {
+.c11 {
   position: absolute;
   width: 10rem;
   display: -webkit-box;
@@ -6455,7 +6398,7 @@ exports[`Storyshots Header Header itself 1`] = `
   z-index: 999;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6468,7 +6411,7 @@ exports[`Storyshots Header Header itself 1`] = `
   height: 5.25rem;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6479,11 +6422,35 @@ exports[`Storyshots Header Header itself 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c6 {
   display: none;
 }
 
-.c22 {
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c21 {
   border: none;
   background: transparent;
   padding: 0;
@@ -6507,16 +6474,16 @@ exports[`Storyshots Header Header itself 1`] = `
   outline: 0.25rem solid transparent;
 }
 
-.c22:focus {
+.c21:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c22:active {
+.c21:active {
   outline: none;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6539,28 +6506,28 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #858196;
 }
 
-.c25:focus {
+.c24:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c25:active {
+.c24:active {
   outline: none;
 }
 
-.c25:hover,
-.c25:focus {
+.c24:hover,
+.c24:focus {
   color: #fff;
 }
 
-.c26 {
+.c25 {
   max-width: 320px;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.c24 {
+.c23 {
   display: block;
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
@@ -6574,31 +6541,31 @@ exports[`Storyshots Header Header itself 1`] = `
   color: #858196;
 }
 
-.c24:hover,
-.c24:active,
-.c24.active {
+.c23:hover,
+.c23:active,
+.c23.active {
   color: #fff;
 }
 
-.c24:focus {
+.c23:focus {
   color: #fff;
   outline: 0.25rem solid transparent;
 }
 
-.c24:focus:focus {
+.c23:focus:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c24:focus:active {
+.c23:focus:active {
   outline: none;
 }
 
-.c23 {
+.c22 {
   list-style-type: none;
 }
 
-.c20 {
+.c19 {
   position: fixed;
   background: #090329;
   height: 100vh;
@@ -6752,13 +6719,13 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c17 {
+  .c16 {
     display: none;
   }
 }
 
 @media screen and (max-width:959px) {
-  .c19 {
+  .c18 {
     z-index: 9;
     background-color: rgba(51,51,51,0.2);
     content: '';
@@ -6778,27 +6745,27 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c15 {
+  .c14 {
     margin-right: 0.375rem;
   }
 
-  .c15:last-child {
-    margin-right: 0rem;
-  }
-}
-
-@media screen and (min-width:960px) {
-  .c8 {
-    margin-right: 0.375rem;
-  }
-
-  .c8:last-child {
+  .c14:last-child {
     margin-right: 0rem;
   }
 }
 
 @media screen and (min-width:960px) {
   .c7 {
+    margin-right: 0.375rem;
+  }
+
+  .c7:last-child {
+    margin-right: 0rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c6 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -6816,7 +6783,7 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:600px) and (max-width:959px) {
-  .c20 {
+  .c19 {
     width: 18.4375rem;
     left: auto;
     right: 0;
@@ -6824,7 +6791,7 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c20 {
+  .c19 {
     display: none;
   }
 }
@@ -6856,415 +6823,411 @@ exports[`Storyshots Header Header itself 1`] = `
           ]
         }
       >
-        <header
+        <nav
           className="c4"
         >
-          <nav
+          <div
             className="c5"
           >
-            <div
-              className="c6"
+            <a
+              aria-current="page"
+              className=""
+              href="/"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              style={Object {}}
+            >
+              <img
+                alt="yld logo"
+                height="48"
+                role="link"
+                src="test-file-stub"
+              />
+            </a>
+          </div>
+          <ul
+            className="c6"
+          >
+            <li
+              aria-expanded={false}
+              aria-haspopup="true"
+              className="c7"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+            >
+              <span
+                className="c8"
+                tabIndex="0"
+              >
+                <span
+                  className="c9"
+                >
+                  Services
+                </span>
+                <svg
+                  className="c10"
+                  height="6"
+                  viewBox="0 0 6 6"
+                  width="6"
+                >
+                  <polyline
+                    points="0,0 6,0 6,6"
+                  />
+                </svg>
+              </span>
+              <ul
+                className="c11"
+              >
+                <li
+                  className="c12"
+                >
+                  <a
+                    className="c13"
+                    href="/engineering/"
+                    onClick={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Engineering
+                  </a>
+                </li>
+                <li
+                  className="c12"
+                >
+                  <a
+                    className="c13"
+                    href="/design/"
+                    onClick={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Design
+                  </a>
+                </li>
+                <li
+                  className="c12"
+                >
+                  <a
+                    className="c13"
+                    href="/training/"
+                    onClick={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Training
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="c14"
+            >
+              <a
+                className="c15"
+                href="/our-work/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Our work
+              </a>
+            </li>
+            <li
+              className="c14"
+            >
+              <a
+                className="c15"
+                href="https://medium.com/yld-engineering-blog/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Blog
+              </a>
+            </li>
+            <li
+              aria-expanded={false}
+              aria-haspopup="true"
+              className="c7"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseDown={[Function]}
+            >
+              <span
+                className="c8"
+                tabIndex="0"
+              >
+                <span
+                  className="c9"
+                >
+                  About
+                </span>
+                <svg
+                  className="c10"
+                  height="6"
+                  viewBox="0 0 6 6"
+                  width="6"
+                >
+                  <polyline
+                    points="0,0 6,0 6,6"
+                  />
+                </svg>
+              </span>
+              <ul
+                className="c11"
+              >
+                <li
+                  className="c12"
+                >
+                  <a
+                    className="c13"
+                    href="/about-us/"
+                    onClick={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Our team
+                  </a>
+                </li>
+                <li
+                  className="c12"
+                >
+                  <a
+                    className="c13"
+                    href="/contact/"
+                    onClick={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Contact
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li
+              className="c14"
+            >
+              <a
+                className="c15"
+                href="/join-us/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Join us
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <button
+          className="c16"
+          onClick={[Function]}
+        >
+          <svg
+            className="c17"
+            height="18"
+            title="open menu"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0 16h24v2H0zm0-8h24v2H0zm0-8h24v2H0z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </button>
+        <div
+          className="c18"
+          onClick={[Function]}
+        />
+        <nav
+          className="c19"
+          open={false}
+        >
+          <div
+            className="c20"
+          >
+            <button
+              className="c21"
+              onClick={[Function]}
+            >
+              <img
+                alt="Close menu"
+                src="test-file-stub"
+              />
+            </button>
+          </div>
+          <ul>
+            <li
+              className="c22"
             >
               <a
                 aria-current="page"
-                className=""
+                className="c23 active"
                 href="/"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
+                states={
+                  Object {
+                    "default": Array [
+                      "
+  color: #858196;
+",
+                    ],
+                    "hoverActive": Array [
+                      "
+  color: ",
+                      [Function],
+                      ";
+",
+                    ],
+                  }
+                }
                 style={Object {}}
               >
-                <img
-                  alt="yld logo"
-                  height="48"
-                  role="link"
-                  src="test-file-stub"
-                />
+                Home
               </a>
-            </div>
-            <ul
-              className="c7"
+            </li>
+            <li
+              aria-expanded={false}
+              aria-haspopup="true"
             >
-              <li
-                aria-expanded={false}
-                aria-haspopup="true"
-                className="c8"
-                onBlur={[Function]}
-                onClick={[Function]}
+              <span
+                className="c24"
                 onFocus={[Function]}
                 onMouseDown={[Function]}
-              >
-                <span
-                  className="c9"
-                  tabIndex="0"
-                >
-                  <span
-                    className="c10"
-                  >
-                    Services
-                  </span>
-                  <svg
-                    className="c11"
-                    height="6"
-                    viewBox="0 0 6 6"
-                    width="6"
-                  >
-                    <polyline
-                      points="0,0 6,0 6,6"
-                    />
-                  </svg>
-                </span>
-                <ul
-                  className="c12"
-                >
-                  <li
-                    className="c13"
-                  >
-                    <a
-                      className="c14"
-                      href="/engineering/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Engineering
-                    </a>
-                  </li>
-                  <li
-                    className="c13"
-                  >
-                    <a
-                      className="c14"
-                      href="/design/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Design
-                    </a>
-                  </li>
-                  <li
-                    className="c13"
-                  >
-                    <a
-                      className="c14"
-                      href="/training/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Training
-                    </a>
-                  </li>
-                </ul>
-              </li>
-              <li
-                className="c15"
-              >
-                <a
-                  className="c16"
-                  href="/our-work/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  Our work
-                </a>
-              </li>
-              <li
-                className="c15"
-              >
-                <a
-                  className="c16"
-                  href="https://medium.com/yld-engineering-blog/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Blog
-                </a>
-              </li>
-              <li
-                aria-expanded={false}
-                aria-haspopup="true"
-                className="c8"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-              >
-                <span
-                  className="c9"
-                  tabIndex="0"
-                >
-                  <span
-                    className="c10"
-                  >
-                    About
-                  </span>
-                  <svg
-                    className="c11"
-                    height="6"
-                    viewBox="0 0 6 6"
-                    width="6"
-                  >
-                    <polyline
-                      points="0,0 6,0 6,6"
-                    />
-                  </svg>
-                </span>
-                <ul
-                  className="c12"
-                >
-                  <li
-                    className="c13"
-                  >
-                    <a
-                      className="c14"
-                      href="/about-us/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Our team
-                    </a>
-                  </li>
-                  <li
-                    className="c13"
-                  >
-                    <a
-                      className="c14"
-                      href="/contact/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Contact
-                    </a>
-                  </li>
-                </ul>
-              </li>
-              <li
-                className="c15"
-              >
-                <a
-                  className="c16"
-                  href="/join-us/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  Join us
-                </a>
-              </li>
-            </ul>
-          </nav>
-          <button
-            className="c17"
-            onClick={[Function]}
-          >
-            <svg
-              className="c18"
-              height="18"
-              title="open menu"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M0 16h24v2H0zm0-8h24v2H0zm0-8h24v2H0z"
-                fillRule="evenodd"
-              />
-            </svg>
-          </button>
-          <div
-            className="c19"
-            onClick={[Function]}
-          />
-          <nav
-            className="c20"
-            open={false}
-          >
-            <div
-              className="c21"
-            >
-              <button
-                className="c22"
-                onClick={[Function]}
-              >
-                <img
-                  alt="Close menu"
-                  src="test-file-stub"
-                />
-              </button>
-            </div>
-            <ul>
-              <li
-                className="c23"
-              >
-                <a
-                  aria-current="page"
-                  className="c24 active"
-                  href="/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                  states={
-                    Object {
-                      "default": Array [
-                        "
-  color: #858196;
-",
-                      ],
-                      "hoverActive": Array [
-                        "
-  color: ",
-                        [Function],
-                        ";
-",
-                      ],
-                    }
-                  }
-                  style={Object {}}
-                >
-                  Home
-                </a>
-              </li>
-              <li
-                aria-expanded={false}
-                aria-haspopup="true"
+                tabIndex="0"
               >
                 <span
                   className="c25"
-                  onFocus={[Function]}
-                  onMouseDown={[Function]}
-                  tabIndex="0"
                 >
-                  <span
-                    className="c26"
-                  >
-                    Services
-                  </span>
-                  <svg
-                    className="c11"
-                    height="6"
-                    viewBox="0 0 6 6"
-                    width="6"
-                  >
-                    <polyline
-                      points="0,0 6,0 6,6"
-                    />
-                  </svg>
+                  Services
                 </span>
-              </li>
-              <li
+                <svg
+                  className="c10"
+                  height="6"
+                  viewBox="0 0 6 6"
+                  width="6"
+                >
+                  <polyline
+                    points="0,0 6,0 6,6"
+                  />
+                </svg>
+              </span>
+            </li>
+            <li
+              className="c22"
+            >
+              <a
                 className="c23"
-              >
-                <a
-                  className="c24"
-                  href="/our-work/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                  states={
-                    Object {
-                      "default": Array [
-                        "
+                href="/our-work/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                states={
+                  Object {
+                    "default": Array [
+                      "
   color: #858196;
 ",
-                      ],
-                      "hoverActive": Array [
-                        "
+                    ],
+                    "hoverActive": Array [
+                      "
   color: ",
-                        [Function],
-                        ";
+                      [Function],
+                      ";
 ",
-                      ],
-                    }
+                    ],
                   }
-                >
-                  Our work
-                </a>
-              </li>
-              <li
-                className="c23"
+                }
               >
-                <a
-                  className="c24"
-                  href="https://medium.com/yld-engineering-blog/"
-                  rel="noopener noreferrer"
-                  states={
-                    Object {
-                      "default": Array [
-                        "
+                Our work
+              </a>
+            </li>
+            <li
+              className="c22"
+            >
+              <a
+                className="c23"
+                href="https://medium.com/yld-engineering-blog/"
+                rel="noopener noreferrer"
+                states={
+                  Object {
+                    "default": Array [
+                      "
   color: #858196;
 ",
-                      ],
-                      "hoverActive": Array [
-                        "
+                    ],
+                    "hoverActive": Array [
+                      "
   color: ",
-                        [Function],
-                        ";
+                      [Function],
+                      ";
 ",
-                      ],
-                    }
+                    ],
                   }
-                  target="_blank"
-                >
-                  Blog
-                </a>
-              </li>
-              <li
-                aria-expanded={false}
-                aria-haspopup="true"
+                }
+                target="_blank"
+              >
+                Blog
+              </a>
+            </li>
+            <li
+              aria-expanded={false}
+              aria-haspopup="true"
+            >
+              <span
+                className="c24"
+                onFocus={[Function]}
+                onMouseDown={[Function]}
+                tabIndex="0"
               >
                 <span
                   className="c25"
-                  onFocus={[Function]}
-                  onMouseDown={[Function]}
-                  tabIndex="0"
                 >
-                  <span
-                    className="c26"
-                  >
-                    About
-                  </span>
-                  <svg
-                    className="c11"
-                    height="6"
-                    viewBox="0 0 6 6"
-                    width="6"
-                  >
-                    <polyline
-                      points="0,0 6,0 6,6"
-                    />
-                  </svg>
+                  About
                 </span>
-              </li>
-              <li
+                <svg
+                  className="c10"
+                  height="6"
+                  viewBox="0 0 6 6"
+                  width="6"
+                >
+                  <polyline
+                    points="0,0 6,0 6,6"
+                  />
+                </svg>
+              </span>
+            </li>
+            <li
+              className="c22"
+            >
+              <a
                 className="c23"
-              >
-                <a
-                  className="c24"
-                  href="/join-us/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                  states={
-                    Object {
-                      "default": Array [
-                        "
+                href="/join-us/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                states={
+                  Object {
+                    "default": Array [
+                      "
   color: #858196;
 ",
-                      ],
-                      "hoverActive": Array [
-                        "
+                    ],
+                    "hoverActive": Array [
+                      "
   color: ",
-                        [Function],
-                        ";
+                      [Function],
+                      ";
 ",
-                      ],
-                    }
+                    ],
                   }
-                >
-                  Join us
-                </a>
-              </li>
-            </ul>
-          </nav>
-        </header>
+                }
+              >
+                Join us
+              </a>
+            </li>
+          </ul>
+        </nav>
       </div>
     </div>
   </div>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6615,15 +6615,7 @@ exports[`Storyshots Header Header itself 1`] = `
 
 .c4 {
   padding-bottom: 2.25rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   height: 7.5rem;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c0 {
@@ -6632,7 +6624,7 @@ exports[`Storyshots Header Header itself 1`] = `
   background: #fff;
   width: 100%;
   max-width: unset;
-  z-index: 100;
+  z-index: 999;
 }
 
 @media (min-width:29.4375em) {
@@ -6888,17 +6880,8 @@ exports[`Storyshots Header Header itself 1`] = `
   }
 }
 
-@media (min-width:43.8125em) {
-  .c0 {
-    max-width: none;
-    margin: 0 auto;
-  }
-}
-
 @media (min-width:74.8125em) {
   .c0 {
-    right: 50%;
-    margin: 0 -50% 0 0;
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -7700,8 +7683,8 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
     </a>
     <a
       className="c3"
-      color="#1d1d1d"
       href="/engineering"
+      isServicePage={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
     >
@@ -8241,8 +8224,8 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
       </a>
       <a
         className="c4"
-        color="#fff"
         href="/engineering"
+        isServicePage={false}
         onClick={[Function]}
         onMouseEnter={[Function]}
       >

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -75,16 +75,16 @@ exports[`Storyshots About Us Page Components Multiple StaffCards 1`] = `
   font-weight: 700;
 }
 
-.c7 {
-  padding-bottom: 2.25rem;
-}
-
 .c3 {
   padding-bottom: 2.25rem;
 }
 
 .c4 {
   padding-bottom: 1.5rem;
+}
+
+.c7 {
+  padding-bottom: 2.25rem;
 }
 
 .c11 {
@@ -784,16 +784,16 @@ exports[`Storyshots About Us Page Components StaffCard 1`] = `
   font-weight: 700;
 }
 
-.c7 {
-  padding-bottom: 2.25rem;
-}
-
 .c3 {
   padding-bottom: 2.25rem;
 }
 
 .c4 {
   padding-bottom: 1.5rem;
+}
+
+.c7 {
+  padding-bottom: 2.25rem;
 }
 
 .c11 {
@@ -6155,7 +6155,7 @@ exports[`Storyshots Grid Rows and Colums (some combinations) 1`] = `
 `;
 
 exports[`Storyshots Header Header itself 1`] = `
-.c0 {
+.c1 {
   max-width: calc(100% - 48px);
   position: relative;
   margin-left: auto;
@@ -6164,7 +6164,7 @@ exports[`Storyshots Header Header itself 1`] = `
   padding-right: 0;
 }
 
-.c2 {
+.c3 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -6184,7 +6184,7 @@ exports[`Storyshots Header Header itself 1`] = `
   display: block;
 }
 
-.c1 {
+.c2 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
@@ -6198,403 +6198,7 @@ exports[`Storyshots Header Header itself 1`] = `
   display: flex;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-content: stretch;
-  -ms-flex-line-pack: stretch;
-  align-content: stretch;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c3 {
-  padding-bottom: 2.25rem;
-}
-
-.c17 {
-  fill: #333333;
-}
-
-.c16 {
-  border: none;
-  background: transparent;
-  padding: 0;
-  min-width: 3rem;
-  min-height: 3rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 5rem;
-  height: 5rem;
-  margin: 0.25rem -1.25rem 0.25rem 0.25rem;
-  outline: 0.25rem solid transparent;
-}
-
-.c16:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c16:active {
-  outline: none;
-}
-
-.c18 {
-  display: none;
-}
-
-.c15 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
-  background: linear-gradient(to right,#616161 0%,transparent 0);
-  outline: none;
-  font-weight: 400;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
-  padding: 0.625rem 0.9375rem 0.875rem;
-  outline: 0.25rem solid transparent;
-}
-
-.c15:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c15:active {
-  outline: none;
-}
-
-.c14 {
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  background: #fff;
-  color: #333333;
-}
-
-.c14:hover,
-.c14 > a:hover {
-  background: #333333;
-  color: #a9a9a9;
-}
-
-.c14 > a:active {
-  background: #333333;
-  color: #fff;
-}
-
-.c14 > a.active {
-  background: #fff;
-  color: #828282;
-}
-
-.c14 > a.active:active {
-  background: #fff;
-  color: #828282;
-}
-
-.c14 > a.active:hover {
-  color: #333333;
-}
-
-.c10 {
-  stroke: currentColor;
-  stroke-width: 0.1875rem;
-  fill: none;
-  -webkit-transform: rotate(135deg);
-  -ms-transform: rotate(135deg);
-  transform: rotate(135deg);
-  -webkit-transition: -webkit-transform 0s ease 0.1s;
-  -webkit-transition: transform 0s ease 0.1s;
-  transition: transform 0s ease 0.1s;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c13 {
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
-  background: linear-gradient(to right,#616161 0%,transparent 0);
-  outline: none;
-  font-weight: 400;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
-  padding: 0.625rem 0.9375rem 0.875rem;
-  outline: 0.25rem solid transparent;
-  width: 100%;
-  background: #f9f9f9;
-  color: #828282;
-}
-
-.c13:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c13:active {
-  outline: none;
-}
-
-.c13:hover,
-.c13.active {
-  color: #333333;
-}
-
-.c7 {
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-  position: relative;
-  cursor: pointer;
-  background: transparent;
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-}
-
-.c7 > span {
-  background: #fff;
-  color: #333333;
-}
-
-.c7 > span:hover {
-  background: #333333;
-  color: #a9a9a9;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-transition: outline 300ms ease-out;
-  transition: outline 300ms ease-out;
-  z-index: 2;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
-  background: linear-gradient(to right,#616161 0%,transparent 0);
-  outline: none;
-  font-weight: 400;
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
-  padding: 0.625rem 0.9375rem 0.875rem;
-  outline: 0.25rem solid transparent;
-}
-
-.c8:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c8:active {
-  outline: none;
-}
-
-.c9 {
-  padding-right: 0.375rem;
-  outline: none;
-}
-
-.c11 {
-  position: absolute;
-  width: 10rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  top: 3rem;
-  left: -9999px;
-  opacity: 0;
-  -webkit-transition: opacity 300ms ease;
-  transition: opacity 300ms ease;
-  background: #f9f9f9;
-  z-index: 999;
-}
-
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c6 {
-  display: none;
-}
-
-.c21 {
-  border: none;
-  background: transparent;
-  padding: 0;
-  min-width: 3rem;
-  min-height: 3rem;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 5rem;
-  height: 5rem;
-  margin: 0.25rem;
-  outline: 0.25rem solid transparent;
-}
-
-.c21:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c21:active {
-  outline: none;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
-  background: linear-gradient(to right,#616161 0%,transparent 0);
-  outline: none;
-  font-weight: 400;
-  font-size: 1.3125rem;
-  line-height: 1.5rem;
-  padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
-  margin: 0.25rem;
-  outline: 0.25rem solid transparent;
-  color: #858196;
-}
-
-.c24:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c24:active {
-  outline: none;
-}
-
-.c24:hover,
-.c24:focus {
-  color: #fff;
-}
-
-.c25 {
-  max-width: 320px;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c23 {
-  display: block;
-  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
-  background: linear-gradient(to right,#616161 0%,transparent 0);
-  outline: none;
-  font-weight: 400;
-  font-size: 1.3125rem;
-  line-height: 1.5rem;
-  padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
-  margin: 0.25rem;
-  color: #858196;
-}
-
-.c23:hover,
-.c23:active,
-.c23.active {
-  color: #fff;
-}
-
-.c23:focus {
-  color: #fff;
-  outline: 0.25rem solid transparent;
-}
-
-.c23:focus:focus {
-  outline-color: #65FFCD;
-  z-index: 1;
-}
-
-.c23:focus:active {
-  outline: none;
-}
-
-.c22 {
-  list-style-type: none;
-}
-
-.c19 {
-  position: fixed;
-  background: #090329;
-  height: 100vh;
-  width: 100vw;
-  left: 0;
-  top: 0;
-  z-index: 999;
-  -webkit-transform: translateX(100%);
-  -ms-transform: translateX(100%);
-  transform: translateX(100%);
-  -webkit-transition: -webkit-transform 200ms ease-in-out;
-  -webkit-transition: transform 200ms ease-in-out;
-  transition: transform 200ms ease-in-out;
-}
-
-.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6620,146 +6224,595 @@ exports[`Storyshots Header Header itself 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  height: 84px;
+  width: 100%;
+  height: 100%;
+  -webkit-flex-basis: 100%;
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-content: stretch;
+  -ms-flex-line-pack: stretch;
+  align-content: stretch;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c19 {
+  fill: #333333;
+}
+
+.c18 {
+  border: none;
+  background: transparent;
+  padding: 0;
+  min-width: 3rem;
+  min-height: 3rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  width: 5rem;
+  height: 5rem;
+  right: 1.5rem;
+  margin: 0.25rem -1.25rem 0.25rem 0.25rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c18:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c18:active {
+  outline: none;
+}
+
+.c20 {
+  display: none;
+}
+
+.c17 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c17:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c17:active {
+  outline: none;
+}
+
+.c16 {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #fff;
+  color: #333333;
+}
+
+.c16:hover,
+.c16 > a:hover {
+  background: #333333;
+  color: #a9a9a9;
+}
+
+.c16 > a:active {
+  background: #333333;
+  color: #fff;
+}
+
+.c16 > a.active {
+  background: #fff;
+  color: #828282;
+}
+
+.c16 > a.active:active {
+  background: #fff;
+  color: #828282;
+}
+
+.c16 > a.active:hover {
+  color: #333333;
+}
+
+.c12 {
+  stroke: currentColor;
+  stroke-width: 0.1875rem;
+  fill: none;
+  -webkit-transform: rotate(135deg);
+  -ms-transform: rotate(135deg);
+  transform: rotate(135deg);
+  -webkit-transition: -webkit-transform 0s ease 0.1s;
+  -webkit-transition: transform 0s ease 0.1s;
+  transition: transform 0s ease 0.1s;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+  width: 100%;
+  background: #f9f9f9;
+  color: #828282;
+}
+
+.c15:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c15:active {
+  outline: none;
+}
+
+.c15:hover,
+.c15.active {
+  color: #333333;
+}
+
+.c9 {
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  position: relative;
+  cursor: pointer;
+  background: transparent;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
+
+.c9 > span {
+  background: #fff;
+  color: #333333;
+}
+
+.c9 > span:hover {
+  background: #333333;
+  color: #a9a9a9;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transition: outline 300ms ease-out;
+  transition: outline 300ms ease-out;
+  z-index: 2;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.5rem;
+  padding: 0.625rem 0.9375rem 0.875rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c10:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c10:active {
+  outline: none;
+}
+
+.c11 {
+  padding-right: 0.375rem;
+  outline: none;
+}
+
+.c13 {
+  position: absolute;
+  width: 10rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  top: 3rem;
+  left: -9999px;
+  opacity: 0;
+  -webkit-transition: opacity 300ms ease;
+  transition: opacity 300ms ease;
+  background: #f9f9f9;
+  z-index: 999;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 1.5rem;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  display: none;
+}
+
+.c23 {
+  border: none;
+  background: transparent;
+  padding: 0;
+  min-width: 3rem;
+  min-height: 3rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 5rem;
+  height: 5rem;
+  margin: 0.25rem;
+  outline: 0.25rem solid transparent;
+}
+
+.c23:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c23:active {
+  outline: none;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.3125rem;
+  line-height: 1.5rem;
+  padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
+  margin: 0.25rem;
+  outline: 0.25rem solid transparent;
+  color: #858196;
+}
+
+.c26:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c26:active {
+  outline: none;
+}
+
+.c26:hover,
+.c26:focus {
+  color: #fff;
+}
+
+.c27 {
+  max-width: 320px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c25 {
+  display: block;
+  -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+  background: linear-gradient(to right,#616161 0%,transparent 0);
+  outline: none;
+  font-weight: 400;
+  font-size: 1.3125rem;
+  line-height: 1.5rem;
+  padding: 0.5625rem 2.125rem 0.4375rem 1.25rem;
+  margin: 0.25rem;
+  color: #858196;
+}
+
+.c25:hover,
+.c25:active,
+.c25.active {
+  color: #fff;
+}
+
+.c25:focus {
+  color: #fff;
+  outline: 0.25rem solid transparent;
+}
+
+.c25:focus:focus {
+  outline-color: #65FFCD;
+  z-index: 1;
+}
+
+.c25:focus:active {
+  outline: none;
+}
+
+.c24 {
+  list-style-type: none;
+}
+
+.c21 {
+  position: fixed;
+  background: #090329;
+  height: 100vh;
+  width: 100vw;
+  left: 0;
+  top: 0;
+  z-index: 999;
+  -webkit-transform: translateX(100%);
+  -ms-transform: translateX(100%);
+  transform: translateX(100%);
+  -webkit-transition: -webkit-transform 200ms ease-in-out;
+  -webkit-transition: transform 200ms ease-in-out;
+  transition: transform 200ms ease-in-out;
+}
+
+.c4 {
+  padding-bottom: 2.25rem;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 7.5rem;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 {
+  position: fixed;
+  height: 5.25rem;
+  background: #fff;
+  width: 100%;
+  max-width: unset;
+  z-index: 100;
+  box-shadow: 0 9px 9px -9px #e6e6e6;
 }
 
 @media (min-width:29.4375em) {
-  .c0 {
+  .c1 {
     max-width: calc(100% - 72px);
   }
 }
 
 @media (min-width:34.5625em) {
-  .c0 {
+  .c1 {
     max-width: 480px;
   }
 }
 
 @media (min-width:43.8125em) {
-  .c0 {
+  .c1 {
     max-width: none;
   }
 }
 
 @media (min-width:74.8125em) {
-  .c0 {
+  .c1 {
     max-width: 1100px;
   }
 }
 
 @media screen and (min-width:29.4375rem) {
-  .c0 {
+  .c1 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
 @media screen and (min-width:34.5625rem) {
-  .c0 {
+  .c1 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
 @media screen and (min-width:43.8125rem) {
-  .c0 {
+  .c1 {
     padding-left: 2.625rem;
     padding-right: 2.625rem;
   }
 }
 
 @media screen and (min-width:56.3125rem) {
-  .c0 {
+  .c1 {
     padding-left: 3rem;
     padding-right: 3rem;
   }
 }
 
 @media screen and (min-width:74.8125rem) {
-  .c0 {
+  .c1 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
 @media screen and (min-width:29.4375rem) {
-  .c2 {
+  .c3 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
 @media screen and (min-width:34.5625rem) {
-  .c2 {
+  .c3 {
     padding-left: 0;
     padding-right: 0;
   }
 }
 
 @media screen and (min-width:43.8125rem) {
-  .c2 {
+  .c3 {
     padding-left: 1.3125rem;
     padding-right: 1.3125rem;
   }
 }
 
 @media screen and (min-width:56.3125rem) {
-  .c2 {
+  .c3 {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
   }
 }
 
 @media screen and (min-width:74.8125rem) {
-  .c2 {
+  .c3 {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
   }
 }
 
 @media screen and (min-width:29.4375rem) {
-  .c1 {
+  .c2 {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
 @media screen and (min-width:34.5625rem) {
-  .c1 {
+  .c2 {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
 @media screen and (min-width:43.8125rem) {
-  .c1 {
+  .c2 {
     margin-left: -1.3125rem;
     margin-right: -1.3125rem;
   }
 }
 
 @media screen and (min-width:56.3125rem) {
-  .c1 {
+  .c2 {
     margin-left: -1.5rem;
     margin-right: -1.5rem;
   }
 }
 
 @media screen and (min-width:74.8125rem) {
-  .c1 {
+  .c2 {
     margin-left: -1.5rem;
     margin-right: -1.5rem;
   }
 }
 
+@media (min-width:29.4375em) {
+  .c18 {
+    right: 2.25rem;
+  }
+}
+
+@media (min-width:34.5625em) {
+  .c18 {
+    right: calc(50% - 240px);
+  }
+}
+
+@media (min-width:43.8125em) {
+  .c18 {
+    right: 0;
+  }
+}
+
 @media screen and (min-width:960px) {
-  .c16 {
+  .c18 {
     display: none;
   }
 }
 
 @media screen and (max-width:959px) {
-  .c18 {
+  .c20 {
     z-index: 9;
     background-color: rgba(51,51,51,0.2);
     content: '';
@@ -6779,27 +6832,52 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c14 {
+  .c16 {
     margin-right: 0.375rem;
   }
 
-  .c14:last-child {
+  .c16:last-child {
     margin-right: 0rem;
   }
 }
 
 @media screen and (min-width:960px) {
-  .c7 {
+  .c9 {
     margin-right: 0.375rem;
   }
 
-  .c7:last-child {
+  .c9:last-child {
     margin-right: 0rem;
   }
 }
 
-@media screen and (min-width:960px) {
+@media (min-width:29.4375em) {
   .c6 {
+    padding-left: 2.25rem;
+  }
+}
+
+@media (min-width:34.5625em) {
+  .c6 {
+    padding-left: calc(50% - 240px);
+  }
+}
+
+@media (min-width:43.8125em) {
+  .c6 {
+    padding-left: 0;
+    width: 100%;
+  }
+}
+
+@media (min-width:74.8125em) {
+  .c6 {
+    width: 68.75rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c8 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -6820,7 +6898,7 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:600px) and (max-width:959px) {
-  .c19 {
+  .c21 {
     width: 18.4375rem;
     left: auto;
     right: 0;
@@ -6828,16 +6906,38 @@ exports[`Storyshots Header Header itself 1`] = `
 }
 
 @media screen and (min-width:960px) {
-  .c19 {
+  .c21 {
     display: none;
   }
 }
 
+@media (min-width:43.8125em) {
+  .c0 {
+    max-width: none;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:74.8125em) {
+  .c0 {
+    right: 50%;
+    margin: 0 -50% 0 0;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+}
+
 <div
-  className="c0"
+  className="c0 c1"
 >
   <div
-    className="c1"
+    className="c2"
     style={
       Object {
         "overflow": "visible",
@@ -6845,7 +6945,7 @@ exports[`Storyshots Header Header itself 1`] = `
     }
   >
     <div
-      className="c2"
+      className="c3"
       style={
         Object {
           "overflow": "visible",
@@ -6858,211 +6958,215 @@ exports[`Storyshots Header Header itself 1`] = `
       }
     >
       <div
-        className="c3"
+        className="c4"
       >
         <header
-          className="c4"
+          className="c5"
         >
           <div
-            className="c5"
+            className="c6"
           >
-            <a
-              aria-current="page"
-              className=""
-              href="/"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              style={Object {}}
+            <div
+              className="c7"
             >
-              <img
-                alt="yld logo"
-                height="48"
-                role="link"
-                src="test-file-stub"
-              />
-            </a>
+              <a
+                aria-current="page"
+                className=""
+                href="/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                style={Object {}}
+              >
+                <img
+                  alt="yld logo"
+                  height="48"
+                  role="link"
+                  src="test-file-stub"
+                />
+              </a>
+            </div>
+            <nav>
+              <ul
+                className="c8"
+              >
+                <li
+                  aria-expanded={false}
+                  aria-haspopup="true"
+                  className="c9"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                >
+                  <span
+                    className="c10"
+                    tabIndex="0"
+                  >
+                    <span
+                      className="c11"
+                    >
+                      Services
+                    </span>
+                    <svg
+                      className="c12"
+                      height="6"
+                      viewBox="0 0 6 6"
+                      width="6"
+                    >
+                      <polyline
+                        points="0,0 6,0 6,6"
+                      />
+                    </svg>
+                  </span>
+                  <ul
+                    className="c13"
+                  >
+                    <li
+                      className="c14"
+                    >
+                      <a
+                        className="c15"
+                        href="/engineering/"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                      >
+                        Engineering
+                      </a>
+                    </li>
+                    <li
+                      className="c14"
+                    >
+                      <a
+                        className="c15"
+                        href="/design/"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                      >
+                        Design
+                      </a>
+                    </li>
+                    <li
+                      className="c14"
+                    >
+                      <a
+                        className="c15"
+                        href="/training/"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                      >
+                        Training
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+                <li
+                  className="c16"
+                >
+                  <a
+                    className="c17"
+                    href="/our-work/"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Our work
+                  </a>
+                </li>
+                <li
+                  className="c16"
+                >
+                  <a
+                    className="c17"
+                    href="https://medium.com/yld-engineering-blog/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Blog
+                  </a>
+                </li>
+                <li
+                  aria-expanded={false}
+                  aria-haspopup="true"
+                  className="c9"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                >
+                  <span
+                    className="c10"
+                    tabIndex="0"
+                  >
+                    <span
+                      className="c11"
+                    >
+                      About
+                    </span>
+                    <svg
+                      className="c12"
+                      height="6"
+                      viewBox="0 0 6 6"
+                      width="6"
+                    >
+                      <polyline
+                        points="0,0 6,0 6,6"
+                      />
+                    </svg>
+                  </span>
+                  <ul
+                    className="c13"
+                  >
+                    <li
+                      className="c14"
+                    >
+                      <a
+                        className="c15"
+                        href="/about-us/"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                      >
+                        Our team
+                      </a>
+                    </li>
+                    <li
+                      className="c14"
+                    >
+                      <a
+                        className="c15"
+                        href="/contact/"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                      >
+                        Contact
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+                <li
+                  className="c16"
+                >
+                  <a
+                    className="c17"
+                    href="/join-us/"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    Join us
+                  </a>
+                </li>
+              </ul>
+            </nav>
           </div>
-          <nav>
-            <ul
-              className="c6"
-            >
-              <li
-                aria-expanded={false}
-                aria-haspopup="true"
-                className="c7"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-              >
-                <span
-                  className="c8"
-                  tabIndex="0"
-                >
-                  <span
-                    className="c9"
-                  >
-                    Services
-                  </span>
-                  <svg
-                    className="c10"
-                    height="6"
-                    viewBox="0 0 6 6"
-                    width="6"
-                  >
-                    <polyline
-                      points="0,0 6,0 6,6"
-                    />
-                  </svg>
-                </span>
-                <ul
-                  className="c11"
-                >
-                  <li
-                    className="c12"
-                  >
-                    <a
-                      className="c13"
-                      href="/engineering/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Engineering
-                    </a>
-                  </li>
-                  <li
-                    className="c12"
-                  >
-                    <a
-                      className="c13"
-                      href="/design/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Design
-                    </a>
-                  </li>
-                  <li
-                    className="c12"
-                  >
-                    <a
-                      className="c13"
-                      href="/training/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Training
-                    </a>
-                  </li>
-                </ul>
-              </li>
-              <li
-                className="c14"
-              >
-                <a
-                  className="c15"
-                  href="/our-work/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  Our work
-                </a>
-              </li>
-              <li
-                className="c14"
-              >
-                <a
-                  className="c15"
-                  href="https://medium.com/yld-engineering-blog/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Blog
-                </a>
-              </li>
-              <li
-                aria-expanded={false}
-                aria-haspopup="true"
-                className="c7"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-              >
-                <span
-                  className="c8"
-                  tabIndex="0"
-                >
-                  <span
-                    className="c9"
-                  >
-                    About
-                  </span>
-                  <svg
-                    className="c10"
-                    height="6"
-                    viewBox="0 0 6 6"
-                    width="6"
-                  >
-                    <polyline
-                      points="0,0 6,0 6,6"
-                    />
-                  </svg>
-                </span>
-                <ul
-                  className="c11"
-                >
-                  <li
-                    className="c12"
-                  >
-                    <a
-                      className="c13"
-                      href="/about-us/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Our team
-                    </a>
-                  </li>
-                  <li
-                    className="c12"
-                  >
-                    <a
-                      className="c13"
-                      href="/contact/"
-                      onClick={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                    >
-                      Contact
-                    </a>
-                  </li>
-                </ul>
-              </li>
-              <li
-                className="c14"
-              >
-                <a
-                  className="c15"
-                  href="/join-us/"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                >
-                  Join us
-                </a>
-              </li>
-            </ul>
-          </nav>
           <button
-            className="c16"
+            className="c18"
             onClick={[Function]}
           >
             <svg
-              className="c17"
+              className="c19"
               height="18"
               title="open menu"
               width="24"
@@ -7075,18 +7179,18 @@ exports[`Storyshots Header Header itself 1`] = `
             </svg>
           </button>
           <div
-            className="c18"
+            className="c20"
             onClick={[Function]}
           />
           <nav
-            className="c19"
+            className="c21"
             open={false}
           >
             <div
-              className="c20"
+              className="c22"
             >
               <button
-                className="c21"
+                className="c23"
                 onClick={[Function]}
               >
                 <img
@@ -7097,11 +7201,11 @@ exports[`Storyshots Header Header itself 1`] = `
             </div>
             <ul>
               <li
-                className="c22"
+                className="c24"
               >
                 <a
                   aria-current="page"
-                  className="c23 active"
+                  className="c25 active"
                   href="/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -7131,18 +7235,18 @@ exports[`Storyshots Header Header itself 1`] = `
                 aria-haspopup="true"
               >
                 <span
-                  className="c24"
+                  className="c26"
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   tabIndex="0"
                 >
                   <span
-                    className="c25"
+                    className="c27"
                   >
                     Services
                   </span>
                   <svg
-                    className="c10"
+                    className="c12"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -7154,10 +7258,10 @@ exports[`Storyshots Header Header itself 1`] = `
                 </span>
               </li>
               <li
-                className="c22"
+                className="c24"
               >
                 <a
-                  className="c23"
+                  className="c25"
                   href="/our-work/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -7182,10 +7286,10 @@ exports[`Storyshots Header Header itself 1`] = `
                 </a>
               </li>
               <li
-                className="c22"
+                className="c24"
               >
                 <a
-                  className="c23"
+                  className="c25"
                   href="https://medium.com/yld-engineering-blog/"
                   rel="noopener noreferrer"
                   states={
@@ -7214,18 +7318,18 @@ exports[`Storyshots Header Header itself 1`] = `
                 aria-haspopup="true"
               >
                 <span
-                  className="c24"
+                  className="c26"
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   tabIndex="0"
                 >
                   <span
-                    className="c25"
+                    className="c27"
                   >
                     About
                   </span>
                   <svg
-                    className="c10"
+                    className="c12"
                     height="6"
                     viewBox="0 0 6 6"
                     width="6"
@@ -7237,10 +7341,10 @@ exports[`Storyshots Header Header itself 1`] = `
                 </span>
               </li>
               <li
-                className="c22"
+                className="c24"
               >
                 <a
-                  className="c23"
+                  className="c25"
                   href="/join-us/"
                   onClick={[Function]}
                   onMouseEnter={[Function]}
@@ -7274,38 +7378,7 @@ exports[`Storyshots Header Header itself 1`] = `
 `;
 
 exports[`Storyshots Header TopNavbar - light theme 1`] = `
-Array [
-  .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-<div
-    className="c0"
-  >
-    <a
-      aria-current="page"
-      className=""
-      href="/"
-      onClick={[Function]}
-      onMouseEnter={[Function]}
-      style={Object {}}
-    >
-      <img
-        alt="yld logo"
-        height="48"
-        role="link"
-        src="test-file-stub"
-      />
-    </a>
-  </div>,
-  .c2 {
+.c4 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
@@ -7317,16 +7390,16 @@ Array [
   outline: 0.25rem solid transparent;
 }
 
-.c2:focus {
+.c4:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c2:active {
+.c4:active {
   outline: none;
 }
 
-.c1 {
+.c3 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   display: -webkit-box;
   display: -webkit-flex;
@@ -7336,47 +7409,95 @@ Array [
   color: #333333;
 }
 
-.c1:hover,
-.c1 > a:hover {
+.c3:hover,
+.c3 > a:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c1 > a:active {
+.c3 > a:active {
   background: #333333;
   color: #fff;
 }
 
-.c1 > a.active {
+.c3 > a.active {
   background: #fff;
   color: #828282;
 }
 
-.c1 > a.active:active {
+.c3 > a.active:active {
   background: #fff;
   color: #828282;
 }
 
-.c1 > a.active:hover {
+.c3 > a.active:hover {
   color: #333333;
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 1.5rem;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
   display: none;
 }
 
 @media screen and (min-width:960px) {
-  .c1 {
+  .c3 {
     margin-right: 0.375rem;
   }
 
-  .c1:last-child {
+  .c3:last-child {
     margin-right: 0rem;
   }
 }
 
-@media screen and (min-width:960px) {
+@media (min-width:29.4375em) {
   .c0 {
+    padding-left: 2.25rem;
+  }
+}
+
+@media (min-width:34.5625em) {
+  .c0 {
+    padding-left: calc(50% - 240px);
+  }
+}
+
+@media (min-width:43.8125em) {
+  .c0 {
+    padding-left: 0;
+    width: 100%;
+  }
+}
+
+@media (min-width:74.8125em) {
+  .c0 {
+    width: 68.75rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c2 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -7396,68 +7517,11 @@ Array [
   }
 }
 
-<nav>
-    <ul
-      className="c0"
-    >
-      <li
-        className="c1"
-      >
-        <a
-          aria-current="page"
-          className="c2 active"
-          href="/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
-          style={Object {}}
-        >
-          Here
-        </a>
-      </li>
-      <li
-        className="c1"
-      >
-        <a
-          className="c2"
-          href="/there"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
-        >
-          There
-        </a>
-      </li>
-      <li
-        className="c1"
-      >
-        <a
-          className="c2"
-          href="/https:/uk.linkedin.com/"
-          onClick={[Function]}
-          onMouseEnter={[Function]}
-        >
-          LinkedIn (external anchor)
-        </a>
-      </li>
-    </ul>
-  </nav>,
-]
-`;
-
-exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
-Array [
-  .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
 <div
-    className="c0"
+  className="c0"
+>
+  <div
+    className="c1"
   >
     <a
       aria-current="page"
@@ -7474,8 +7538,56 @@ Array [
         src="test-file-stub"
       />
     </a>
-  </div>,
-  .c9 {
+  </div>
+  <nav>
+    <ul
+      className="c2"
+    >
+      <li
+        className="c3"
+      >
+        <a
+          aria-current="page"
+          className="c4 active"
+          href="/"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+          style={Object {}}
+        >
+          Here
+        </a>
+      </li>
+      <li
+        className="c3"
+      >
+        <a
+          className="c4"
+          href="/there"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          There
+        </a>
+      </li>
+      <li
+        className="c3"
+      >
+        <a
+          className="c4"
+          href="/https:/uk.linkedin.com/"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          LinkedIn (external anchor)
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;
+
+exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
+.c11 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
@@ -7487,16 +7599,16 @@ Array [
   outline: 0.25rem solid transparent;
 }
 
-.c9:focus {
+.c11:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c9:active {
+.c11:active {
   outline: none;
 }
 
-.c8 {
+.c10 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   display: -webkit-box;
   display: -webkit-flex;
@@ -7506,32 +7618,32 @@ Array [
   color: #333333;
 }
 
-.c8:hover,
-.c8 > a:hover {
+.c10:hover,
+.c10 > a:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c8 > a:active {
+.c10 > a:active {
   background: #333333;
   color: #fff;
 }
 
-.c8 > a.active {
+.c10 > a.active {
   background: #fff;
   color: #828282;
 }
 
-.c8 > a.active:active {
+.c10 > a.active:active {
   background: #fff;
   color: #828282;
 }
 
-.c8 > a.active:hover {
+.c10 > a.active:hover {
   color: #333333;
 }
 
-.c4 {
+.c6 {
   stroke: currentColor;
   stroke-width: 0.1875rem;
   fill: none;
@@ -7543,14 +7655,14 @@ Array [
   transition: transform 0s ease 0.1s;
 }
 
-.c6 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c7 {
+.c9 {
   -webkit-transition: opacity 200ms ease-out, color 200ms ease-out;
   transition: opacity 200ms ease-out, color 200ms ease-out;
   background: linear-gradient(to right,#616161 0%,transparent 0);
@@ -7565,21 +7677,21 @@ Array [
   color: #828282;
 }
 
-.c7:focus {
+.c9:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c7:active {
+.c9:active {
   outline: none;
 }
 
-.c7:hover,
-.c7.active {
+.c9:hover,
+.c9.active {
   color: #333333;
 }
 
-.c1 {
+.c3 {
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   position: relative;
   cursor: pointer;
@@ -7587,17 +7699,17 @@ Array [
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
-.c1 > span {
+.c3 > span {
   background: #fff;
   color: #333333;
 }
 
-.c1 > span:hover {
+.c3 > span:hover {
   background: #333333;
   color: #a9a9a9;
 }
 
-.c2 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7620,21 +7732,21 @@ Array [
   outline: 0.25rem solid transparent;
 }
 
-.c2:focus {
+.c4:focus {
   outline-color: #65FFCD;
   z-index: 1;
 }
 
-.c2:active {
-  outline: none;
-}
-
-.c3 {
-  padding-right: 0.375rem;
+.c4:active {
   outline: none;
 }
 
 .c5 {
+  padding-right: 0.375rem;
+  outline: none;
+}
+
+.c7 {
   position: absolute;
   width: 10rem;
   display: -webkit-box;
@@ -7654,31 +7766,79 @@ Array [
 }
 
 .c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding-left: 1.5rem;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
   display: none;
 }
 
 @media screen and (min-width:960px) {
-  .c8 {
+  .c10 {
     margin-right: 0.375rem;
   }
 
-  .c8:last-child {
+  .c10:last-child {
     margin-right: 0rem;
   }
 }
 
 @media screen and (min-width:960px) {
-  .c1 {
+  .c3 {
     margin-right: 0.375rem;
   }
 
-  .c1:last-child {
+  .c3:last-child {
     margin-right: 0rem;
   }
 }
 
-@media screen and (min-width:960px) {
+@media (min-width:29.4375em) {
   .c0 {
+    padding-left: 2.25rem;
+  }
+}
+
+@media (min-width:34.5625em) {
+  .c0 {
+    padding-left: calc(50% - 240px);
+  }
+}
+
+@media (min-width:43.8125em) {
+  .c0 {
+    padding-left: 0;
+    width: 100%;
+  }
+}
+
+@media (min-width:74.8125em) {
+  .c0 {
+    width: 68.75rem;
+  }
+}
+
+@media screen and (min-width:960px) {
+  .c2 {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -7698,30 +7858,52 @@ Array [
   }
 }
 
-<nav>
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <a
+      aria-current="page"
+      className=""
+      href="/"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      style={Object {}}
+    >
+      <img
+        alt="yld logo"
+        height="48"
+        role="link"
+        src="test-file-stub"
+      />
+    </a>
+  </div>
+  <nav>
     <ul
-      className="c0"
+      className="c2"
     >
       <li
         aria-expanded={false}
         aria-haspopup="true"
-        className="c1"
+        className="c3"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
         onMouseDown={[Function]}
       >
         <span
-          className="c2"
+          className="c4"
           tabIndex="0"
         >
           <span
-            className="c3"
+            className="c5"
           >
             First dropdown
           </span>
           <svg
-            className="c4"
+            className="c6"
             height="6"
             viewBox="0 0 6 6"
             width="6"
@@ -7732,13 +7914,13 @@ Array [
           </svg>
         </span>
         <ul
-          className="c5"
+          className="c7"
         >
           <li
-            className="c6"
+            className="c8"
           >
             <a
-              className="c7"
+              className="c9"
               href="/item-1/"
               onClick={[Function]}
               onMouseDown={[Function]}
@@ -7748,10 +7930,10 @@ Array [
             </a>
           </li>
           <li
-            className="c6"
+            className="c8"
           >
             <a
-              className="c7"
+              className="c9"
               href="/item-2/"
               onClick={[Function]}
               onMouseDown={[Function]}
@@ -7761,10 +7943,10 @@ Array [
             </a>
           </li>
           <li
-            className="c6"
+            className="c8"
           >
             <a
-              className="c7"
+              className="c9"
               href="/item-3/"
               onClick={[Function]}
               onMouseDown={[Function]}
@@ -7776,10 +7958,10 @@ Array [
         </ul>
       </li>
       <li
-        className="c8"
+        className="c10"
       >
         <a
-          className="c9"
+          className="c11"
           href="/anchor/"
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -7788,10 +7970,10 @@ Array [
         </a>
       </li>
       <li
-        className="c8"
+        className="c10"
       >
         <a
-          className="c9"
+          className="c11"
           href="https://uk.linkedin.com/"
           rel="noopener noreferrer"
           target="_blank"
@@ -7802,23 +7984,23 @@ Array [
       <li
         aria-expanded={false}
         aria-haspopup="true"
-        className="c1"
+        className="c3"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
         onMouseDown={[Function]}
       >
         <span
-          className="c2"
+          className="c4"
           tabIndex="0"
         >
           <span
-            className="c3"
+            className="c5"
           >
             Second dropdown
           </span>
           <svg
-            className="c4"
+            className="c6"
             height="6"
             viewBox="0 0 6 6"
             width="6"
@@ -7829,13 +8011,13 @@ Array [
           </svg>
         </span>
         <ul
-          className="c5"
+          className="c7"
         >
           <li
-            className="c6"
+            className="c8"
           >
             <a
-              className="c7"
+              className="c9"
               href="/go-here/"
               onClick={[Function]}
               onMouseDown={[Function]}
@@ -7845,10 +8027,10 @@ Array [
             </a>
           </li>
           <li
-            className="c6"
+            className="c8"
           >
             <a
-              className="c7"
+              className="c9"
               href="/go-there/"
               onClick={[Function]}
               onMouseDown={[Function]}
@@ -7860,10 +8042,10 @@ Array [
         </ul>
       </li>
       <li
-        className="c8"
+        className="c10"
       >
         <a
-          className="c9"
+          className="c11"
           href="/last-anchor/"
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -7872,8 +8054,8 @@ Array [
         </a>
       </li>
     </ul>
-  </nav>,
-]
+  </nav>
+</div>
 `;
 
 exports[`Storyshots Image with file url 1`] = `


### PR DESCRIPTION
## Description - [391](https://trello.com/c/LrHVVlju/391-8-topnav-persistance-on-scrolling)

- [x] The topnav should be kept on the top of the window as the user scrolls
- [x] It should change its appearance (background to white / shadow) accordingly.
- [x] added a shadow gradient
- [x] Done for desktop
- [x] Done for mobile

nb: 
- there are 5 breakpoints to take into consideration as the topNav follow the structure of the main Layout.
- With the topNav being now positioned fixed, some other elements had to be adjusted depending on that change.
- The topNav header does not appear on Modal pages. So far only training pages have modals. I used a trainingModalRegExp to make sure that the header still renders on `training` or `training/#node-js` urls (which are navigation pages) but does not on a url such as `training/node` that is a modal. A bit confusing to read but easier to understand/see if you navigate on the deployed Netlify url.

Also done:
- [x] update snapshots
- [x] Update storybook

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
