### PR TITLE
Implement LogoGrid Zeplin specs on live website

### DIFF
--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -14,7 +14,7 @@ const Partners = ({ title, partners }) => (
       <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
         <SectionTitle>{title}</SectionTitle>
       </Padding>
-      <LogoGrid logos={partners} />
+      <LogoGrid companies={partners} />
     </Padding>
   </Grid>
 )

--- a/src/components/AboutUs/Partners.js
+++ b/src/components/AboutUs/Partners.js
@@ -1,23 +1,9 @@
 import React from 'react'
 import { Padding } from 'styled-components-spacing'
 
-import Image from '../Common/Image'
-import { Grid, Row } from '../grid'
+import { Grid } from '../grid'
 import { SectionTitle } from '../Typography'
-import PaddedCol from './PaddedCol'
-import ExternalAnchor from '../Common/ExternalAnchor'
-
-const Partner = ({ image, url }) => (
-  <PaddedCol width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 3 / 12]}>
-    <ExternalAnchor href={url}>
-      <Image
-        image={image}
-        width="250px"
-        style={{ filter: 'grayscale(1)', saturate: '0' }}
-      />
-    </ExternalAnchor>
-  </PaddedCol>
-)
+import LogoGrid from '../Common/LogoGrid'
 
 const Partners = ({ title, partners }) => (
   <Grid>
@@ -28,11 +14,7 @@ const Partners = ({ title, partners }) => (
       <Padding bottom={{ smallPhone: 3, tablet: 4 }}>
         <SectionTitle>{title}</SectionTitle>
       </Padding>
-      <Row>
-        {partners.map((partner, idx) => (
-          <Partner key={idx} image={partner.image} url={partner.url} />
-        ))}
-      </Row>
+      <LogoGrid logos={partners} />
     </Padding>
   </Grid>
 )

--- a/src/components/Common/LogoGrid.js
+++ b/src/components/Common/LogoGrid.js
@@ -11,31 +11,27 @@ const Column = styled(Col)`
   padding-bottom: ${props => props.theme.spacing[1]};
 `
 
-const LogoGrid = ({ logos = [] }) =>
-  logos ? (
-    <Row>
-      {logos.map(logo => (
-        <Column
-          width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]}
-          key={logo.id}
-        >
-          {logo.url ? (
-            <ExternalAnchor href={logo.url}>
-              <Image
-                image={logo.image}
-                width="250px"
-                style={{ filter: 'grayscale(1)', saturate: '0' }}
-              />
-            </ExternalAnchor>
-          ) : (
+const LogoGrid = ({ logos }) => (
+  <Row>
+    {logos.map(logo => (
+      <Column width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]} key={logo.id}>
+        {logo.url ? (
+          <ExternalAnchor href={logo.url}>
             <Image
-              image={logo}
+              image={logo.image}
+              width="250px"
               style={{ filter: 'grayscale(1)', saturate: '0' }}
             />
-          )}
-        </Column>
-      ))}
-    </Row>
-  ) : null
+          </ExternalAnchor>
+        ) : (
+          <Image
+            image={logo}
+            style={{ filter: 'grayscale(1)', saturate: '0' }}
+          />
+        )}
+      </Column>
+    ))}
+  </Row>
+)
 
 export default LogoGrid

--- a/src/components/Common/LogoGrid.js
+++ b/src/components/Common/LogoGrid.js
@@ -10,18 +10,18 @@ const Column = styled(Col)`
   padding-bottom: ${props => props.theme.spacing[1]};
 `
 
-const Companies = ({ companies = [] }) =>
-  companies ? (
+const LogoGrid = ({ logos = [] }) =>
+  logos ? (
     <Row>
-      {companies.map(company => (
+      {logos.map(logo => (
         <Column
           width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]}
-          key={company.id}
+          key={logo.id}
         >
-          <Image image={company} />
+          <Image image={logo} />
         </Column>
       ))}
     </Row>
   ) : null
 
-export default Companies
+export default LogoGrid

--- a/src/components/Common/LogoGrid.js
+++ b/src/components/Common/LogoGrid.js
@@ -11,21 +11,24 @@ const Column = styled(Col)`
   padding-bottom: ${props => props.theme.spacing[1]};
 `
 
-const LogoGrid = ({ logos }) => (
+const LogoGrid = ({ companies }) => (
   <Row>
-    {logos.map(logo => (
-      <Column width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]} key={logo.id}>
-        {logo.url ? (
-          <ExternalAnchor href={logo.url}>
+    {companies.map(company => (
+      <Column
+        width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]}
+        key={company.id}
+      >
+        {company.url ? (
+          <ExternalAnchor href={company.url}>
             <Image
-              image={logo.image}
+              image={company.image}
               width="250px"
               style={{ filter: 'grayscale(1)', saturate: '0' }}
             />
           </ExternalAnchor>
         ) : (
           <Image
-            image={logo}
+            image={company}
             style={{ filter: 'grayscale(1)', saturate: '0' }}
           />
         )}

--- a/src/components/Common/LogoGrid.js
+++ b/src/components/Common/LogoGrid.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Row, Col } from '../grid'
 import styled from 'styled-components'
 import Image from '../Common/Image'
+import ExternalAnchor from '../Common/ExternalAnchor'
 
 const Column = styled(Col)`
   max-height: 108px;
@@ -18,7 +19,20 @@ const LogoGrid = ({ logos = [] }) =>
           width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]}
           key={logo.id}
         >
-          <Image image={logo} />
+          {logo.url ? (
+            <ExternalAnchor href={logo.url}>
+              <Image
+                image={logo.image}
+                width="250px"
+                style={{ filter: 'grayscale(1)', saturate: '0' }}
+              />
+            </ExternalAnchor>
+          ) : (
+            <Image
+              image={logo}
+              style={{ filter: 'grayscale(1)', saturate: '0' }}
+            />
+          )}
         </Column>
       ))}
     </Row>

--- a/src/components/Homepage/companies.js
+++ b/src/components/Homepage/companies.js
@@ -7,6 +7,7 @@ const Column = styled(Col)`
   max-height: 108px;
   display: flex;
   align-items: center;
+  padding-bottom: ${props => props.theme.spacing[1]};
 `
 
 const Companies = ({ companies = [] }) =>
@@ -14,7 +15,7 @@ const Companies = ({ companies = [] }) =>
     <Row>
       {companies.map(company => (
         <Column
-          width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 4, 1 / 4]}
+          width={[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 3, 1 / 4]}
           key={company.id}
         >
           <Image image={company} />

--- a/src/components/Speciality/Projects.js
+++ b/src/components/Speciality/Projects.js
@@ -4,7 +4,7 @@ import { Row, Col, Grid } from '../grid'
 import { SectionTitle, CardTitle, Subtitle, BodyPrimary } from '../Typography'
 import { Padding } from 'styled-components-spacing'
 import { AnimatedLink, CardHeader, PosterImage } from '../Common/animatedLink'
-import Companies from '../Homepage/companies'
+import LogoGrid from '../Common/LogoGrid'
 
 const Emphasis = styled.em`
   color: ${props => props.theme.colors.secondaryText};
@@ -45,7 +45,7 @@ const CompaniesHelped = ({ clients, noOther }) => (
         </Padding>
       </Col>
     </Row>
-    <Companies companies={clients} />
+    <LogoGrid logos={clients} />
   </Fragment>
 )
 

--- a/src/components/Speciality/Projects.js
+++ b/src/components/Speciality/Projects.js
@@ -49,10 +49,10 @@ const CompaniesHelped = ({ clients, noOther }) => (
   </Fragment>
 )
 
-const ProjectsSection = ({ related, title, clients }) => {
-  return related ? (
-    <Grid>
-      <Padding top={5} bottom={5}>
+const ProjectsSection = ({ related, title, clients }) => (
+  <Grid>
+    <Padding top={5} bottom={5}>
+      {related ? (
         <Row>
           <Col width={[0, 0, 0, 0, 1 / 2]}>
             <Padding top={7} bottom={5}>
@@ -83,15 +83,10 @@ const ProjectsSection = ({ related, title, clients }) => {
           )}
           <Col width={[1, 1, 1, 1, 1 / 2]} />
         </Row>
-        <CompaniesHelped clients={clients} />
-      </Padding>
-    </Grid>
-  ) : (
-    <Grid>
-      <Padding top={5} bottom={5}>
-        <CompaniesHelped noOther clients={clients} />
-      </Padding>
-    </Grid>
-  )
-}
+      ) : null}
+      {clients ? <CompaniesHelped clients={clients} /> : null}
+    </Padding>
+  </Grid>
+)
+
 export default ProjectsSection

--- a/src/components/Speciality/Projects.js
+++ b/src/components/Speciality/Projects.js
@@ -45,7 +45,7 @@ const CompaniesHelped = ({ clients, noOther }) => (
         </Padding>
       </Col>
     </Row>
-    <LogoGrid logos={clients} />
+    <LogoGrid companies={clients} />
   </Fragment>
 )
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import { Grid } from '../components/grid'
 import Head from '../components/Common/Head'
 import Layout from '../components/layout'
 import Statement from '../components/Common/Statement'
-import Companies from '../components/Homepage/companies'
+import LogoGrid from '../components/Common/LogoGrid'
 import Blog from '../components/Homepage/blog'
 import Events from '../components/Homepage/events/index'
 import Jobs from '../components/Homepage/jobs'
@@ -25,7 +25,7 @@ const IndexPage = ({
         <Padding top={{ smallPhone: 4 }} bottom={3}>
           <Statement noPadding richText={content.seoText.content[0].content} />
           <Padding bottom={{ smallPhone: 2, smallTablet: 4, desktop: 4 }} />
-          <Companies companies={content.companies} />
+          <LogoGrid logos={content.companies} />
         </Padding>
       </Grid>
     </GreyBackground>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -25,7 +25,7 @@ const IndexPage = ({
         <Padding top={{ smallPhone: 4 }} bottom={3}>
           <Statement noPadding richText={content.seoText.content[0].content} />
           <Padding bottom={{ smallPhone: 2, smallTablet: 4, desktop: 4 }} />
-          <LogoGrid logos={content.companies} />
+          <LogoGrid companies={content.companies} />
         </Padding>
       </Grid>
     </GreyBackground>


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/JSh3ln1T/379-logogrid-fixes)

Zeplin documentation for this component was created after the 'logo grids' on our website were built. This PR brings the existing pages in line with the Zeplin spec. It involves alterations to:
1. Statement/Companies section of the homepage
2. Projects section of all Speciality (aka SEO) pages
3. Technology Partnerships section of About Us page

This PR will:
- use the old `Companies` component from the homepage as the basis for a new `LogoGrid` component, now inside the Common folder
- alter this component to have 3 columns on small tablet (used to have 4 columns)
- add 12px spacing between each row of logos
- re-use this component on the Speciality template
- make the 'Other companies we helped' section of the Speciality template optional (i.e. remove this subtitle if/when there are no logos entered into Contentful) - fixes [another bug ticket](https://trello.com/c/0Xl8J07p/492-other-clients-section-of-speciality-page-sometimes-has-no-logos-but-still-has-subtitle-showing)
- re-use this component on the About Us page for the Technology Partnerships section, so that the same column spacing rules apply there  
(Should also fix [this bug ticket](https://trello.com/c/KMY5ABt5/488-logogrid-bug-on-about-us-page))

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
