### PR TITLE
Fix tutorials section bug

### DIFF
--- a/src/components/Speciality/Tutorials.js
+++ b/src/components/Speciality/Tutorials.js
@@ -5,7 +5,7 @@ import GreyBackground from '../Common/GreyBackground'
 import { Grid } from '../grid'
 import TitleAndMediaList from '../Common/TitleAndMediaList'
 
-const TutorialsSection = ({ tutorials }) => {
+const TutorialsSection = ({ speciality, tutorials }) => {
   const mediaItems = tutorials
     .slice(0, 3)
     .map(({ id, title, link, additionalInfo }) => ({
@@ -21,7 +21,7 @@ const TutorialsSection = ({ tutorials }) => {
         <Padding vertical={{ desktop: 5, smallPhone: 3.5 }}>
           <TitleAndMediaList
             title="Tutorials"
-            description="NodeJS tutorials created by members of YLD for the community."
+            description={`${speciality} tutorials created by members of YLD for the community.`}
             mediaItems={mediaItems}
             CTALink="http://nodetuts.com/"
             CTAText="More tutorials"

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -27,6 +27,7 @@ const Speciality = ({
   },
   location
 }) => {
+  console.log('speciality', speciality)
   const {
     relatedProjects,
     title,
@@ -40,7 +41,9 @@ const Speciality = ({
   } = speciality
 
   const posts = filteredPosts.map(({ node }) => node)
+  const talks = getExternalType(speciality, `Talk`)
   const tutorials = getExternalType(speciality, `Tutorial`)
+  const books = getExternalType(speciality, `Book`)
 
   return (
     <Layout backgroundColor="blue" location={location}>
@@ -59,10 +62,7 @@ const Speciality = ({
         title={title}
       />
       <EventSection events={events} title={title} eventIcon={eventIcon} />
-      <TalksSection
-        talks={getExternalType(speciality, `Talk`)}
-        videoIcon={videoIcon}
-      />
+      <TalksSection talks={talks} videoIcon={videoIcon} />
       <BlogListing
         title="Blog posts"
         description={`${title} articles created by members of YLD for the community.`}
@@ -71,7 +71,7 @@ const Speciality = ({
       {tutorials.length > 0 ? (
         <TutorialsSection speciality={title} tutorials={tutorials} />
       ) : null}
-      <BooksSection title={title} books={getExternalType(speciality, `Book`)} />
+      <BooksSection title={title} books={books} />
       <GetInTouch
         title={`Talk to us about ${title}`}
         contactText={contactText}

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -67,7 +67,7 @@ const Speciality = ({
         description={`${title} articles created by members of YLD for the community.`}
         posts={posts}
       />
-      {tutorials && tutorials.length > 0 ? (
+      {tutorials && tutorials.length ? (
         <TutorialsSection speciality={title} tutorials={tutorials} />
       ) : null}
       <BooksSection title={title} books={books} />

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -67,7 +67,7 @@ const Speciality = ({
         description={`${title} articles created by members of YLD for the community.`}
         posts={posts}
       />
-      {tutorials.length > 0 ? (
+      {tutorials && tutorials.length > 0 ? (
         <TutorialsSection speciality={title} tutorials={tutorials} />
       ) : null}
       <BooksSection title={title} books={books} />

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -27,7 +27,6 @@ const Speciality = ({
   },
   location
 }) => {
-  console.log('speciality', speciality)
   const {
     relatedProjects,
     title,

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -40,6 +40,7 @@ const Speciality = ({
   } = speciality
 
   const posts = filteredPosts.map(({ node }) => node)
+  const tutorials = getExternalType(speciality, `Tutorial`)
 
   return (
     <Layout backgroundColor="blue" location={location}>
@@ -67,7 +68,9 @@ const Speciality = ({
         description={`${title} articles created by members of YLD for the community.`}
         posts={posts}
       />
-      <TutorialsSection tutorials={getExternalType(speciality, `Tutorial`)} />
+      {tutorials.length > 0 ? (
+        <TutorialsSection speciality={title} tutorials={tutorials} />
+      ) : null}
       <BooksSection title={title} books={getExternalType(speciality, `Book`)} />
       <GetInTouch
         title={`Talk to us about ${title}`}


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/IvgD4Pmh/502-tutorials-section-is-appearing-on-speciality-pages-where-there-are-no-tutorials)

- Remove TutorialsSection from speciality pages that don't have any associated tutorials
- Fix description text, so that 'NodeJS' is no longer hard-coded into this section, regardless of which speciality page it's on

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
