### PR TITLE
Speciality-pages-events-section

### DIFF
--- a/src/components/Header/TopNav/ServiceLink.js
+++ b/src/components/Header/TopNav/ServiceLink.js
@@ -9,7 +9,7 @@ import { servicesRegExp, getService } from './ServicesSpecialitiesMap'
 const StyledServiceLink = styled(Link)`
   font-size: ${remcalc(26)};
   margin-left: ${remcalc(12)};
-  color: ${props => props.theme.colors[props.isServicePage ? 'text' : 'white']};
+  color: ${props => props.theme.colors[props.color]};
 
   @media screen and (min-width: 960px) {
     font-size: ${remcalc(30)};
@@ -17,8 +17,7 @@ const StyledServiceLink = styled(Link)`
 
   &:hover {
     text-decoration: underline;
-    color: ${props =>
-      props.theme.colors[props.isServicePage ? 'text' : 'white']};
+    color: ${props => props.theme.colors[props.color]};
   }
 `
 
@@ -32,7 +31,10 @@ const ServiceLink = ({ path = '/' }) => {
   return (
     <Fragment>
       {isServicePage || isSpecialityPage ? (
-        <StyledServiceLink to={`/${service}`} isServicePage={isServicePage}>
+        <StyledServiceLink
+          to={`/${service}`}
+          color={isServicePage ? 'text' : 'white'}
+        >
           {capitalize(service)}
         </StyledServiceLink>
       ) : null}

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -55,7 +55,7 @@ const EventSection = ({ events, title, eventIcon }) => {
               <Padding bottom={1}>
                 <img src={specialityEventIcon} alt="events icon" />
               </Padding>
-              <SectionTitle>{`Upcoming ${title} events`}</SectionTitle>
+              <SectionTitle>{`Upcoming ${title.trim()} events`}</SectionTitle>
             </div>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -6,7 +6,19 @@ import specialityEventIcon from './assets/events-icon.svg'
 import { Row, Col, Grid } from '../grid'
 import { SectionTitle, Subtitle, BodyPrimary } from '../Typography'
 import ExternalAnchor from '../Common/ExternalAnchor'
+import StyledLink from '../Common/StyledLink'
 import Hr from '../Common/Hr'
+
+const CTA = {
+  link: {
+    withEvents: 'https://www.meetup.com/',
+    withoutEvents: '/contact/'
+  },
+  text: {
+    withEvents: 'More events',
+    withoutEvents: 'Get in touch'
+  }
+}
 
 const noEventsMessage = title =>
   `It looks like there currently aren’t any upcoming ${title} events. You can always check back again later or get in touch if you are interested in potentially hosting one.`
@@ -32,6 +44,7 @@ const getSpecialityEvents = (title, events) =>
 
 const EventSection = ({ events, title, eventIcon }) => {
   const specialityEvents = events ? getSpecialityEvents(title, events) : []
+  const hasEvents = !!specialityEvents.length
 
   return (
     <Grid>
@@ -46,7 +59,7 @@ const EventSection = ({ events, title, eventIcon }) => {
             </div>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            {specialityEvents.length ? (
+            {hasEvents ? (
               <ul>
                 {specialityEvents.map(event => (
                   <li key={`${event.id}`}>
@@ -56,7 +69,7 @@ const EventSection = ({ events, title, eventIcon }) => {
                       </ExternalAnchor>
                     </Subtitle>
                     <BodyPrimary noPaddingTop>
-                      {format(event.date, 'MMMM DD[,] dddd')}
+                      {format(event.startTime, 'MMMM DD[,] dddd')}
                     </BodyPrimary>
                     <Hr />
                   </li>
@@ -65,6 +78,14 @@ const EventSection = ({ events, title, eventIcon }) => {
             ) : (
               noEventsMessage(title)
             )}
+            <Padding top={3}>
+              <StyledLink
+                external
+                href={CTA.link[hasEvents ? 'withEvents' : 'withoutEvents']}
+              >
+                {CTA.text[hasEvents ? 'withEvents' : 'withoutEvents']}
+              </StyledLink>
+            </Padding>
           </Col>
         </Row>
       </Padding>

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -28,7 +28,7 @@ const getSpecialityEvents = (title, events) =>
         isAfter(startTime, endOfYesterday())
     )
     .sort((a, b) => (a.startTime <= b.startTime ? -1 : 1))
-    .slice(0, 3)
+    .slice(0, 5)
 
 const EventSection = ({ events, title, eventIcon }) => {
   const specialityEvents = events ? getSpecialityEvents(title, events) : []

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -6,6 +6,9 @@ import ExternalAnchor from '../Common/ExternalAnchor'
 import { Padding } from 'styled-components-spacing'
 import { format } from 'date-fns'
 
+const noEventsMessage = title =>
+  `It looks like there currently aren’t any upcoming ${title} events. You can always check back again later or get in touch if you are interested in potentially hosting one.`
+
 const EventBorder = styled(Col)`
   border: 1px solid rgba(51, 51, 51, 0.15);
 `
@@ -15,7 +18,7 @@ const EventSection = ({ events, title, eventIcon }) => {
     ({ startTime }) => new Date(startTime) > new Date()
   )
 
-  return futureEvents.length > 0 ? (
+  return (
     <Grid>
       <Padding top={6} bottom={6}>
         <Row>
@@ -23,34 +26,36 @@ const EventSection = ({ events, title, eventIcon }) => {
             <SectionTitle>{`Upcoming ${title} events`}</SectionTitle>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            {futureEvents.map(event => (
-              <EventBorder key={`${event.id}`}>
-                <Padding top={2} bottom={2}>
-                  <Row>
-                    <Col>
-                      <img
-                        src={`https://${eventIcon.file.url}`}
-                        alt={eventIcon.title}
-                      />
-                    </Col>
-                    <Col>
-                      <Subtitle noPadding>
-                        <ExternalAnchor href={event.linkToEvent}>
-                          {event.eventTitle}
-                        </ExternalAnchor>
-                      </Subtitle>
-                      <BodyPrimary noPadding>
-                        {format(new Date(event.date), 'MMMM DD[,] dddd')}
-                      </BodyPrimary>
-                    </Col>
-                  </Row>
-                </Padding>
-              </EventBorder>
-            ))}
+            {futureEvents.length
+              ? futureEvents.map(event => (
+                  <EventBorder key={`${event.id}`}>
+                    <Padding top={2} bottom={2}>
+                      <Row>
+                        <Col>
+                          <img
+                            src={`https://${eventIcon.file.url}`}
+                            alt={eventIcon.title}
+                          />
+                        </Col>
+                        <Col>
+                          <Subtitle noPadding>
+                            <ExternalAnchor href={event.linkToEvent}>
+                              {event.eventTitle}
+                            </ExternalAnchor>
+                          </Subtitle>
+                          <BodyPrimary noPadding>
+                            {format(new Date(event.date), 'MMMM DD[,] dddd')}
+                          </BodyPrimary>
+                        </Col>
+                      </Row>
+                    </Padding>
+                  </EventBorder>
+                ))
+              : noEventsMessage(title)}
           </Col>
         </Row>
       </Padding>
     </Grid>
-  ) : null
+  )
 }
 export default EventSection

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -1,17 +1,15 @@
 import React from 'react'
-import styled from 'styled-components'
+import { format } from 'date-fns'
+import { Padding } from 'styled-components-spacing'
+
+import specialityEventIcon from './assets/events-icon.svg'
 import { Row, Col, Grid } from '../grid'
 import { SectionTitle, Subtitle, BodyPrimary } from '../Typography'
 import ExternalAnchor from '../Common/ExternalAnchor'
-import { Padding } from 'styled-components-spacing'
-import { format } from 'date-fns'
+import Hr from '../Common/Hr'
 
 const noEventsMessage = title =>
   `It looks like there currently aren’t any upcoming ${title} events. You can always check back again later or get in touch if you are interested in potentially hosting one.`
-
-const EventBorder = styled(Col)`
-  border: 1px solid rgba(51, 51, 51, 0.15);
-`
 
 const EventSection = ({ events, title, eventIcon }) => {
   const futureEvents = (events || []).filter(
@@ -23,35 +21,33 @@ const EventSection = ({ events, title, eventIcon }) => {
       <Padding top={6} bottom={6}>
         <Row>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            <SectionTitle>{`Upcoming ${title} events`}</SectionTitle>
+            <div>
+              <Padding bottom={1}>
+                <img src={specialityEventIcon} alt="events icon" />
+              </Padding>
+              <SectionTitle>{`Upcoming ${title} events`}</SectionTitle>
+            </div>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            {futureEvents.length
-              ? futureEvents.map(event => (
-                  <EventBorder key={`${event.id}`}>
-                    <Padding top={2} bottom={2}>
-                      <Row>
-                        <Col>
-                          <img
-                            src={`https://${eventIcon.file.url}`}
-                            alt={eventIcon.title}
-                          />
-                        </Col>
-                        <Col>
-                          <Subtitle noPadding>
-                            <ExternalAnchor href={event.linkToEvent}>
-                              {event.eventTitle}
-                            </ExternalAnchor>
-                          </Subtitle>
-                          <BodyPrimary noPadding>
-                            {format(new Date(event.date), 'MMMM DD[,] dddd')}
-                          </BodyPrimary>
-                        </Col>
-                      </Row>
-                    </Padding>
-                  </EventBorder>
-                ))
-              : noEventsMessage(title)}
+            {futureEvents.length ? (
+              <ul>
+                {futureEvents.map(event => (
+                  <li key={`${event.id}`}>
+                    <Subtitle noPaddingBottom>
+                      <ExternalAnchor href={event.linkToEvent}>
+                        {event.eventTitle}
+                      </ExternalAnchor>
+                    </Subtitle>
+                    <BodyPrimary noPaddingTop>
+                      {format(event.date, 'MMMM DD[,] dddd')}
+                    </BodyPrimary>
+                    <Hr />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              noEventsMessage(title)
+            )}
           </Col>
         </Row>
       </Padding>

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -20,15 +20,18 @@ const isSpecialityEvent = (eventTitle, title) => {
   return eventTitle.toLowerCase().includes(formattedTitle)
 }
 
-const getSpecialityEvents = (events = [], title) =>
-  events.filter(
-    ({ eventTitle, startTime }) =>
-      isSpecialityEvent(eventTitle, title) &&
-      isAfter(startTime, endOfYesterday())
-  )
+const getSpecialityEvents = (title, events) =>
+  events
+    .filter(
+      ({ eventTitle, startTime }) =>
+        isSpecialityEvent(eventTitle, title) &&
+        isAfter(startTime, endOfYesterday())
+    )
+    .sort((a, b) => (a.startTime <= b.startTime ? -1 : 1))
+    .slice(0, 3)
 
 const EventSection = ({ events, title, eventIcon }) => {
-  const specialityEvents = getSpecialityEvents(events, title)
+  const specialityEvents = events ? getSpecialityEvents(title, events) : []
 
   return (
     <Grid>

--- a/src/components/Speciality/Events.js
+++ b/src/components/Speciality/Events.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { format } from 'date-fns'
+import { format, isAfter, endOfYesterday } from 'date-fns'
 import { Padding } from 'styled-components-spacing'
 
 import specialityEventIcon from './assets/events-icon.svg'
@@ -11,10 +11,24 @@ import Hr from '../Common/Hr'
 const noEventsMessage = title =>
   `It looks like there currently aren’t any upcoming ${title} events. You can always check back again later or get in touch if you are interested in potentially hosting one.`
 
-const EventSection = ({ events, title, eventIcon }) => {
-  const futureEvents = (events || []).filter(
-    ({ startTime }) => new Date(startTime) > new Date()
+const isSpecialityEvent = (eventTitle, title) => {
+  const formattedTitle = title
+    .toLowerCase()
+    .replace(/(\.|js)/gi, '')
+    .trim()
+
+  return eventTitle.toLowerCase().includes(formattedTitle)
+}
+
+const getSpecialityEvents = (events = [], title) =>
+  events.filter(
+    ({ eventTitle, startTime }) =>
+      isSpecialityEvent(eventTitle, title) &&
+      isAfter(startTime, endOfYesterday())
   )
+
+const EventSection = ({ events, title, eventIcon }) => {
+  const specialityEvents = getSpecialityEvents(events, title)
 
   return (
     <Grid>
@@ -29,9 +43,9 @@ const EventSection = ({ events, title, eventIcon }) => {
             </div>
           </Col>
           <Col width={[1, 1, 1, 1, 6 / 12]}>
-            {futureEvents.length ? (
+            {specialityEvents.length ? (
               <ul>
-                {futureEvents.map(event => (
+                {specialityEvents.map(event => (
                   <li key={`${event.id}`}>
                     <Subtitle noPaddingBottom>
                       <ExternalAnchor href={event.linkToEvent}>

--- a/src/components/Speciality/assets/events-icon.svg
+++ b/src/components/Speciality/assets/events-icon.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="44px" height="48px" viewBox="0 0 44 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.5 (67469) - http://www.bohemiancoding.com/sketch -->
+    <title>icon: pair programming</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Homepage" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Homepage-/-Desktop" transform="translate(-90.000000, -3966.000000)">
+            <g id="icon-copy-3" transform="translate(90.000000, 3954.000000)">
+                <g id="icon:-pair-programming" transform="translate(0.000000, 12.000000)">
+                    <polygon id="Fill-1" fill="#FF9E80" points="0 48 32 48 32 16 0 16"></polygon>
+                    <g id="Group-11" transform="translate(13.000000, 0.000000)" fill="#333333">
+                        <path d="M24.0003,-0.0001 L24.0003,2.9999 L10.9993,2.9999 L10.9993,-0.0001 L9.0003,-0.0001 L9.0003,2.9999 L3.9993,2.9999 L3.9993,31 L30.9993,31.0009 L30.9993,2.9999 L26.0003,2.9999 L26.0003,-0.0001 L24.0003,-0.0001 Z M26.0003,5.9999 L26.0003,4.9999 L28.9993,4.9999 L28.9993,28.9999 L6.0003,28.9999 L6.0003,4.9999 L9.0003,4.9999 L9.0003,5.9999 L10.9993,5.9999 L10.9993,4.9999 L24.0003,4.9999 L24.0003,5.9999 L26.0003,5.9999 Z" id="Fill-1"></path>
+                        <polygon id="Fill-2" points="0 8 0 35 26 35 26 33 2 33 2 8"></polygon>
+                        <polygon id="Fill-3" points="10 13 13 13 13 10 10 10"></polygon>
+                        <polygon id="Fill-4" points="22 13 25 13 25 10 22 10"></polygon>
+                        <polygon id="Fill-5" points="16 13 19 13 19 10 16 10"></polygon>
+                        <polygon id="Fill-6" points="10 19 13 19 13 16 10 16"></polygon>
+                        <polygon id="Fill-7" points="22 19 25 19 25 16 22 16"></polygon>
+                        <polygon id="Fill-8" points="16 19 19 19 19 16 16 16"></polygon>
+                        <polygon id="Fill-9" points="10 25 13 25 13 22 10 22"></polygon>
+                        <polygon id="Fill-10" points="16 25 19 25 19 22 16 22"></polygon>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -8162,8 +8162,8 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
     </a>
     <a
       className="c3"
+      color="text"
       href="/engineering"
-      isServicePage={true}
       onClick={[Function]}
       onMouseEnter={[Function]}
     >
@@ -8673,8 +8673,8 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
       </a>
       <a
         className="c4"
+        color="white"
         href="/engineering"
-        isServicePage={false}
         onClick={[Function]}
         onMouseEnter={[Function]}
       >


### PR DESCRIPTION
## Description - [493](https://trello.com/c/voeMZxoC/493-blue-sections-on-speciality-pages-are-touching-when-light-section-between-them-is-optional-missing)

put a short summary of what you did here:
- [x] filter events from today's date + by speciality
_nb: the actual filter that was in place was only filtering from date. There do not seem to be tags against an event so the filter I put in place looks for the speciality name within each event.eventTitle (case insensitive). If there is a better way, I'm open to suggestions._
- [x] display list upcoming events within the relevant speciality
- [x] display a simple message and CTA in the event that there are no events
- [x] Unrelated to the task but related to specialities and the task I did before: Resolve React warning in ServiceLink component (custom prop color of type string instead of passing a boolean)
- [ ] style following Zeppelin

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
