### PR TITLE
Fix "when user double clicks on dropdown select button, text is highlighted"

### DIFF
--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -59,9 +59,6 @@ const DropdownNameWrapper = styled.span`
 const DropdownName = styled.span`
   padding-right: ${remcalc(6)};
   outline: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 `
 

--- a/src/components/Header/TopNav/Dropdown.js
+++ b/src/components/Header/TopNav/Dropdown.js
@@ -59,6 +59,10 @@ const DropdownNameWrapper = styled.span`
 const DropdownName = styled.span`
   padding-right: ${remcalc(6)};
   outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 `
 
 const DropdownList = styled.ul`

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -6986,6 +6986,10 @@ exports[`Storyshots Header Header itself 1`] = `
 .c9 {
   padding-right: 0.375rem;
   outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c11 {
@@ -8018,6 +8022,10 @@ exports[`Storyshots Header TopNavbar - Service TopNavBar 1`] = `
 .c7 {
   padding-right: 0.375rem;
   outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c9 {
@@ -8522,6 +8530,10 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
 .c8 {
   padding-right: 0.375rem;
   outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c10 {
@@ -9196,6 +9208,10 @@ exports[`Storyshots Header TopNavbar with dropdowns - light theme 1`] = `
 .c5 {
   padding-right: 0.375rem;
   outline: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c7 {


### PR DESCRIPTION
## Description - [Trello ticket 462](https://trello.com/c/reHuM7mv/462-when-user-clicks-on-dropdown-select-button-text-is-highlighted-on-safari)

When user double clicked on the Navbar drop down (only items that have dropdown were affected), the word got selected per standard browser functionality. This is a patch to disable that selection. 

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
