### PR TITLE
Adjust FeaturedEvent component to allow CTA Text to be editable via Contentful

### DIFF
--- a/src/components/Homepage/events/FeaturedEvent.js
+++ b/src/components/Homepage/events/FeaturedEvent.js
@@ -28,7 +28,7 @@ const FeaturedEvent = ({ events }) => (
             </FixedWidthBodyPrimary>
           </Padding>
           <StyledLink external reverse href={conf.linkToEvent}>
-            Visit the website
+            {conf.ctaText}
           </StyledLink>
         </EventWrapper>
         <Image image={conf.posterImage} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -164,6 +164,7 @@ export const query = graphql`
           id
           eventTitle
           date
+          ctaText
           linkToEvent
           blurb {
             blurb


### PR DESCRIPTION
## Adjust FeaturedEvent component to allow CTA Text to be editable via Contentful - [Trello ticket](https://trello.com/c/dqwiCDPb/513-new-visual-for-the-featured-event-on-the-homepage-yld-leadership-series-stanford-workshops-day)

- Altered the `Meetup Event` content type in Contentful - added a new field called `CTA Text`
- Added new `ctaText` field to graphql query for homepage
- Removed the hard-coded string: 'Visit the website' from our `FeaturedEvent` component and used `ctaText` instead
- Added 'Visit the website' inside the CTA Text field in Contentful, for the React JS Girls Conference event card (so that the live site doesn't break)

Note: once this is merged, I can safely publish the YLD Leadership Series event, which I've already added to Contentful.

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
