### PR TITLE
Add scrollability to SideNav when height is not within window height

### DIFF
--- a/src/components/Header/SideNav/index.js
+++ b/src/components/Header/SideNav/index.js
@@ -16,7 +16,7 @@ const SideNavPanel = styled.nav`
   left: 0;
   top: 0;
   z-index: ${props => props.theme.zIndexes.header};
-  overflow-y: scroll;
+  overflow-y: auto;
   transform: translateX(100%);
   transition: transform ${props => props.theme.animations.fast} ease-in-out;
 

--- a/src/components/Header/SideNav/index.js
+++ b/src/components/Header/SideNav/index.js
@@ -16,6 +16,7 @@ const SideNavPanel = styled.nav`
   left: 0;
   top: 0;
   z-index: ${props => props.theme.zIndexes.header};
+  overflow-y: scroll;
   transform: translateX(100%);
   transition: transform ${props => props.theme.animations.fast} ease-in-out;
 

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -7186,6 +7186,7 @@ exports[`Storyshots Header Header itself 1`] = `
   left: 0;
   top: 0;
   z-index: 999;
+  overflow-y: scroll;
   -webkit-transform: translateX(100%);
   -ms-transform: translateX(100%);
   transform: translateX(100%);

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -7186,7 +7186,7 @@ exports[`Storyshots Header Header itself 1`] = `
   left: 0;
   top: 0;
   z-index: 999;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-transform: translateX(100%);
   -ms-transform: translateX(100%);
   transform: translateX(100%);


### PR DESCRIPTION
## Description - [521](https://trello.com/c/Qqa85JQa/521-unable-to-scroll-sidenav-on-short-screens)

put a short summary of what you did here:
SideNav now scrollable on landscape views for Chrome.

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
