### PR TITLE
Open source branch tweaks

### DIFF
--- a/src/components/Header/navLinks.js
+++ b/src/components/Header/navLinks.js
@@ -13,16 +13,16 @@ const navLinks = [
       {
         label: 'Training',
         to: '/training/'
-      },
-      {
-        label: 'Open Source',
-        to: '/open-source/'
       }
     ]
   },
   {
     label: 'Our work',
     to: '/our-work/'
+  },
+  {
+    label: 'Open Source',
+    to: '/open-source/'
   },
   {
     label: 'Blog',

--- a/src/components/Header/navLinksHelper.js
+++ b/src/components/Header/navLinksHelper.js
@@ -5,8 +5,7 @@ const specialitiesMap = {
   design: [],
   training: [],
   delivery: [],
-  dedicatedTeams: [],
-  openSource: []
+  dedicatedTeams: []
 }
 
 const logoColors = {
@@ -24,7 +23,6 @@ const logoColors = {
   training: {},
   delivery: {},
   dedicatedTeams: {},
-  openSource: {},
   specialityText: theme.colors.blueBg,
   specialityHover: theme.colors.white
 }

--- a/src/pages/open-source.js
+++ b/src/pages/open-source.js
@@ -35,7 +35,7 @@ const OpenSourcePage = props => (
   <StaticQuery
     query={graphql`
       query {
-        contentfulOpenSourcePage(slug: { eq: "open-source" }) {
+        contentfulOpenSourcePage {
           title
           slug
           seoTitle

--- a/src/pages/open-source.js
+++ b/src/pages/open-source.js
@@ -25,8 +25,6 @@ const OpenSource = ({ data }) => {
         title={technologyPartnersSectionTitle}
         partners={technologyPartners}
       />
-      <p>open source page</p>
-      {/* All the sections go herer */}
     </Layout>
   )
 }

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -7537,19 +7537,6 @@ exports[`Storyshots Header Header itself 1`] = `
                     Training
                   </a>
                 </li>
-                <li
-                  className="c12"
-                >
-                  <a
-                    className="c13"
-                    href="/open-source/"
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    Open Source
-                  </a>
-                </li>
               </ul>
             </li>
             <li
@@ -7562,6 +7549,18 @@ exports[`Storyshots Header Header itself 1`] = `
                 onMouseEnter={[Function]}
               >
                 Our work
+              </a>
+            </li>
+            <li
+              className="c14"
+            >
+              <a
+                className="c15"
+                href="/open-source/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                Open Source
               </a>
             </li>
             <li
@@ -7772,6 +7771,34 @@ exports[`Storyshots Header Header itself 1`] = `
                 }
               >
                 Our work
+              </a>
+            </li>
+            <li
+              className="c22"
+            >
+              <a
+                className="c23"
+                href="/open-source/"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                states={
+                  Object {
+                    "default": Array [
+                      "
+  color: #858196;
+",
+                    ],
+                    "hoverActive": Array [
+                      "
+  color: ",
+                      [Function],
+                      ";
+",
+                    ],
+                  }
+                }
+              >
+                Open Source
               </a>
             </li>
             <li


### PR DESCRIPTION
## `open-source-page` branch tweaks - Trello tickets - [open source page](https://trello.com/c/tZl8wbU5/498-open-source-page) & [OS page content type](https://trello.com/c/7dz5YiPC/524-create-new-content-type-for-os-page)

Open source link on navbar shouldn't be inside the 'services' dropdown. See Zeplin:
![image](https://user-images.githubusercontent.com/15656538/58694079-15718f00-838a-11e9-8251-31267a73e758.png)

We don't need the `slug` field in Contentful - this is only used for templates:
![image](https://user-images.githubusercontent.com/15656538/58694126-2de1a980-838a-11e9-94d3-f3118a91dd95.png)


## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
