### PR TITLE
Os partnerships section logos fix

### DIFF
--- a/src/components/OpenSource/Partnerships.js
+++ b/src/components/OpenSource/Partnerships.js
@@ -9,21 +9,21 @@ import Image from '../Common/Image'
 import SubtitleWithBody from '../Common/SubtitleWithBody'
 
 const StyledGrid = styled(Grid)`
-  padding-top: ${props => props.theme.space[4]};
-  padding-bottom: ${props => props.theme.space[5]};
+  padding-top: ${({ theme }) => theme.space[4]};
+  padding-bottom: ${({ theme }) => theme.space[5]};
 
   ${breakpoint('smallTablet')`
-    padding-top: ${props => props.theme.space[6]};
-    padding-bottom: ${props => props.theme.space[7]};
+    padding-top: ${({ theme }) => theme.space[6]};
+    padding-bottom: ${({ theme }) => theme.space[7]};
   `}
 `
 
 const StyledRow = styled(Row)`
-  padding-bottom: ${props => props.theme.space[6]};
+  padding-bottom: ${({ theme }) => theme.space[6]};
 `
 
 const StyledSubtitleWithBodyContainer = styled.div`
-  padding-top: ${props => props.theme.spacing[1]};
+  padding-top: ${({ theme }) => theme.spacing[1]};
 `
 
 const PartnerCol = ({ name, logoDarkTheme, membershipLevel, description }) => (

--- a/src/components/OpenSource/Partnerships.js
+++ b/src/components/OpenSource/Partnerships.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import breakpoint from 'styled-components-breakpoint'
+import remcalc from 'remcalc'
 
 import BlueBackground from '../Common/BlueBackground'
 import { Grid, Row, Col } from '../grid'
@@ -26,9 +27,26 @@ const StyledSubtitleWithBodyContainer = styled.div`
   padding-top: ${({ theme }) => theme.spacing[1]};
 `
 
+const StyledImageContainer = styled.div`
+  width: ${remcalc(200)};
+  height: ${remcalc(90)};
+
+  ${breakpoint('tablet')`
+    width: ${remcalc(165)};
+    height: ${remcalc(75)};
+  `}
+
+  ${breakpoint('desktop')`
+    width: ${remcalc(239)};
+    height: ${remcalc(108)};
+  `}
+`
+
 const PartnerCol = ({ name, logoDarkTheme, membershipLevel, description }) => (
   <Col key={name} width={[1, 1, 1, 1, 1 / 2, 1 / 2, 1 / 3]}>
-    <Image image={logoDarkTheme} alt={`Image of ${logoDarkTheme.title}`} />
+    <StyledImageContainer>
+      <Image image={logoDarkTheme} alt={`Image of ${logoDarkTheme.title}`} />
+    </StyledImageContainer>
     <StyledSubtitleWithBodyContainer>
       <SubtitleWithBody
         subtitle={membershipLevel}

--- a/src/components/OpenSource/Talks.js
+++ b/src/components/OpenSource/Talks.js
@@ -9,22 +9,22 @@ import { Grid, Row, Col } from '../grid'
 import { SectionTitle } from '../Typography'
 
 const StyledGrid = styled(Grid)`
-  padding-top: ${props => props.theme.spacing[2]};
-  padding-bottom: ${props => props.theme.space[5]};
+  padding-top: ${({ theme }) => theme.spacing[2]};
+  padding-bottom: ${({ theme }) => theme.space[5]};
 
   ${breakpoint('smallTablet')`
-    padding-top: ${props => props.theme.space[6]};
-    padding-bottom: ${props => props.theme.space[7]};
+    padding-top: ${({ theme }) => theme.space[6]};
+    padding-bottom: ${({ theme }) => theme.space[7]};
   `}
 `
 
 const StyledImage = styled.img`
-  padding-bottom: ${props => props.theme.spacing[2]};
+  padding-bottom: ${({ theme }) => theme.spacing[2]};
 `
 
 const StyledVideoGridWrapper = styled.div`
-  padding-top: ${props => props.theme.spacing[3]};
-  padding-bottom: ${props => props.theme.spacing[3]};
+  padding-top: ${({ theme }) => theme.spacing[3]};
+  padding-bottom: ${({ theme }) => theme.spacing[3]};
 `
 
 const TalksSection = ({ icon, title, talks, ctaText, ctaLink }) => (


### PR DESCRIPTION
## Description - [Os partnerships section logos fix](https://trello.com/c/RI5Mps0H/526-our-technology-partnerships-section)

put a short summary of what you did here:
- [x] Added a container around the image so it always keep the ratio agreed by design:
```
239px width and 108px high on desktop
This scales down to W165xH75px on Large Tablet
Then W200xH90px on Small Tablet and Mobile
```
- [x] destructure props in CSS in sections I worked with. It's nicer :)

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
