### PR TITLE
Open Source talks section updates

### DIFF
--- a/src/components/OpenSource/Contributions.js
+++ b/src/components/OpenSource/Contributions.js
@@ -6,7 +6,6 @@ import { Grid, Row, Col } from '../grid'
 import { Repo } from '../Common/Repo'
 import { generate } from 'shortid'
 import StyledLink from '../Common/StyledLink'
-import Hr from '../Common/Hr'
 import Image from '../Common/Image'
 import { BodyPrimary } from '../Typography'
 
@@ -112,11 +111,6 @@ const Contributions = ({
           </Col>
         </Row>
       </Wrapper>
-      <Row>
-        <Col width={[1]}>
-          <Hr muted />
-        </Col>
-      </Row>
     </Grid>
   )
 }

--- a/src/pages/open-source.js
+++ b/src/pages/open-source.js
@@ -3,12 +3,13 @@ import { StaticQuery, graphql } from 'gatsby'
 
 import Head from '../components/Common/Head'
 import Layout from '../components/layout'
-import { Grid } from '../components/grid'
+import { Grid, Row, Col } from '../components/grid'
 import EventSection from '../components/Common/Events'
 import BlueBackground from '../components/Common/BlueBackground'
 import CaseStudyPreview from '../components/Common/CaseStudyCards/CaseStudyPreview'
 import Statement from '../components/Common/Statement'
 import SeoLinksContainer from '../components/Common/seoLinksContainer'
+import Hr from '../components/Common/Hr'
 
 import TalksSection from '../components/OpenSource/Talks'
 import PartnershipsSection from '../components/OpenSource/Partnerships'
@@ -91,6 +92,13 @@ const OpenSource = ({ data }) => {
       <OpenDeliverables {...data} />
       <BlueBackground>
         <Contributions {...data} />
+        <Grid>
+          <Row>
+            <Col width={[1]}>
+              <Hr muted />
+            </Col>
+          </Row>
+        </Grid>
         {talks && talks.length && (
           <TalksSection
             icon={talksSectionImage}


### PR DESCRIPTION
## Description - [Open Source talks section updates](https://trello.com/c/04vFF1sg/528-talks-section-for-os-page)

put a short summary of what you did here:
- [x] the line was in the Contributions section was extracted to an independant element.
- [x] the video link is not redirecting to a full screen view but this was solved in Contentful.

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
