### PR TITLE
Fix modal positioning

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,7 +20,17 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-sitemap`,
-    `gatsby-plugin-modal-routing`,
+    {
+      resolve: `gatsby-plugin-modal-routing`,
+      modalProps: {
+        style: {
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0
+        }
+      }
+    },
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,12 +22,16 @@ module.exports = {
     `gatsby-plugin-sitemap`,
     {
       resolve: `gatsby-plugin-modal-routing`,
-      modalProps: {
-        style: {
-          left: 0,
-          right: 0,
-          top: 0,
-          bottom: 0
+      options: {
+        modalProps: {
+          style: {
+            content: {
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: 0
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Passes props to the `react-modal` instance created by the `gatsby-plugin-modal-routing` plugin we're using to correctly setup the modals for their own routes. 

iOS Safari has some sort of issue with `position: fixed;` and `z-index`, or it's actually conforming to the spec, I forget. 

this PR overrides the default, `top`, `left`, `right`, `bottom` values that react-modal initialises with