### PR TITLE
Featured doctor link case study

### DIFF
--- a/src/pages/case-study/doctorlink-setting-up-a-design-system.js
+++ b/src/pages/case-study/doctorlink-setting-up-a-design-system.js
@@ -199,7 +199,7 @@ const IndexPage = props => {
           socialLogo: (caseStudy.posterImage.file || {}).url
         }}
       />
-      <CaseStudyHero caseStudy={caseStudy} />
+      <CaseStudyHero caseStudy={caseStudy} as="h1" />
       <GreyBackground>
         {/* DoctorLink is a healthcare technology company */}
         {shouldRender(data1) && <Statement>{normalise(data1).text}</Statement>}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -127,31 +127,47 @@ export const query = graphql`
         slug
         pageReady
         caseStudies {
-          ... on ContentfulNonTemplatedCaseStudy {
-            title
-            slug
-            posterColor
-            posterImage {
+          ... on Node {
+            ... on ContentfulNonTemplatedCaseStudy {
               title
-              file {
-                url
-              }
-              fluid(maxWidth: 550) {
-                ...GatsbyContentfulFluid_withWebp
+              slug
+              posterColor
+              posterImage {
+                title
+                file {
+                  url
+                }
+                fluid(maxWidth: 550) {
+                  ...GatsbyContentfulFluid_withWebp
+                }
               }
             }
-          }
-          ... on ContentfulTemplatedCaseStudy {
-            title
-            slug
-            posterColor
-            posterImage {
+            ... on ContentfulNonTemplatedCaseStudyV2 {
               title
-              file {
-                url
+              slug
+              posterColor
+              posterImage {
+                title
+                file {
+                  url
+                }
+                fluid(maxWidth: 550) {
+                  ...GatsbyContentfulFluid_withWebp
+                }
               }
-              fluid(maxWidth: 550) {
-                ...GatsbyContentfulFluid_withWebp
+            }
+            ... on ContentfulTemplatedCaseStudy {
+              title
+              slug
+              posterColor
+              posterImage {
+                title
+                file {
+                  url
+                }
+                fluid(maxWidth: 550) {
+                  ...GatsbyContentfulFluid_withWebp
+                }
               }
             }
           }

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -34,7 +34,7 @@ const Service = ({ data: { contentfulService: service }, location }) => {
     <Layout location={location}>
       <Head page={service} />
 
-      <CaseStudyPreview as="h1" caseStudy={service.caseStudies[0]} />
+      <CaseStudyPreview as="h1" caseStudy={service.caseStudies[1]} />
 
       <Statement>
         {service.mainPageIntroSentence.mainPageIntroSentence}
@@ -130,6 +130,20 @@ export const pageQuery = graphql`
             fluid(maxWidth: 600) {
               ...GatsbyContentfulFluid_withWebp
             }
+            title
+            file {
+              url
+            }
+          }
+        }
+        ... on ContentfulNonTemplatedCaseStudyV2 {
+          title
+          slug
+          intro: introSentence {
+            introSentence
+          }
+          posterColor
+          posterImage {
             title
             file {
               url

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -34,7 +34,7 @@ const Service = ({ data: { contentfulService: service }, location }) => {
     <Layout location={location}>
       <Head page={service} />
 
-      <CaseStudyPreview as="h1" caseStudy={service.caseStudies[1]} />
+      <CaseStudyPreview as="h1" caseStudy={service.caseStudies[0]} />
 
       <Statement>
         {service.mainPageIntroSentence.mainPageIntroSentence}

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -59,6 +59,16 @@ const Service = ({ data: { contentfulService: service }, location }) => {
 
 export default Service
 
+/**
+ *
+ * The use of `... on Node` within the relatedCaseStudy and caseStudies
+ * schema is to prevent builds breaking if any of the content-types are
+ * removed from contentful. Previously without the `... on Node` fragment,
+ * the build would break due to type X not being present in any of the
+ * entries. This meant graphql schema would not generate the union type of
+ * all the different case study templates and gatsby build would error.
+ * more info: https://medium.com/@Zepro/contentful-reference-fields-with-gatsby-js-graphql-9f14ed90bdf9
+ */
 export const pageQuery = graphql`
   query($id: String) {
     contentfulService(id: { eq: $id }) {
@@ -70,100 +80,104 @@ export const pageQuery = graphql`
         mainPageIntroSentence
       }
       relatedCaseStudy {
-        ... on ContentfulTemplatedCaseStudy {
-          title
-          slug
-          introSentence
-          posterImage {
+        ... on Node {
+          ... on ContentfulTemplatedCaseStudy {
             title
-            fluid(maxWidth: 600) {
-              ...GatsbyContentfulFluid_withWebp
-            }
-            file {
-              url
-            }
-          }
-          posterColor
-        }
-        ... on ContentfulNonTemplatedCaseStudy {
-          title
-          slug
-          intro: introSentence {
+            slug
             introSentence
+            posterImage {
+              title
+              fluid(maxWidth: 600) {
+                ...GatsbyContentfulFluid_withWebp
+              }
+              file {
+                url
+              }
+            }
+            posterColor
           }
-          posterImage {
+          ... on ContentfulNonTemplatedCaseStudy {
             title
-            fluid(maxWidth: 600) {
-              ...GatsbyContentfulFluid_withWebp
+            slug
+            intro: introSentence {
+              introSentence
             }
-            file {
-              url
+            posterImage {
+              title
+              fluid(maxWidth: 600) {
+                ...GatsbyContentfulFluid_withWebp
+              }
+              file {
+                url
+              }
             }
+            posterColor
           }
-          posterColor
-        }
-        ... on ContentfulNonTemplatedCaseStudyV2 {
-          title
-          slug
-          intro: introSentence {
-            introSentence
-          }
-          posterImage {
+          ... on ContentfulNonTemplatedCaseStudyV2 {
             title
-            fluid(maxWidth: 600) {
-              ...GatsbyContentfulFluid_withWebp
+            slug
+            intro: introSentence {
+              introSentence
             }
-            file {
-              url
+            posterImage {
+              title
+              fluid(maxWidth: 600) {
+                ...GatsbyContentfulFluid_withWebp
+              }
+              file {
+                url
+              }
             }
+            posterColor
           }
-          posterColor
         }
       }
       caseStudies {
-        ... on ContentfulTemplatedCaseStudy {
-          title
-          slug
-          introSentence
-          posterColor
-          posterImage {
-            fluid(maxWidth: 600) {
-              ...GatsbyContentfulFluid_withWebp
-            }
+        ... on Node {
+          ... on ContentfulTemplatedCaseStudy {
             title
-            file {
-              url
-            }
-          }
-        }
-        ... on ContentfulNonTemplatedCaseStudy {
-          title
-          slug
-          intro: introSentence {
+            slug
             introSentence
-          }
-          posterColor
-          posterImage {
-            fluid(maxWidth: 600) {
-              ...GatsbyContentfulFluid_withWebp
+            posterColor
+            posterImage {
+              fluid(maxWidth: 600) {
+                ...GatsbyContentfulFluid_withWebp
+              }
+              title
+              file {
+                url
+              }
             }
+          }
+          ... on ContentfulNonTemplatedCaseStudy {
             title
-            file {
-              url
+            slug
+            intro: introSentence {
+              introSentence
+            }
+            posterColor
+            posterImage {
+              fluid(maxWidth: 600) {
+                ...GatsbyContentfulFluid_withWebp
+              }
+              title
+              file {
+                url
+              }
             }
           }
-        }
-        ... on ContentfulNonTemplatedCaseStudyV2 {
-          title
-          slug
-          intro: introSentence {
-            introSentence
-          }
-          posterColor
-          posterImage {
+          ... on ContentfulNonTemplatedCaseStudyV2 {
             title
-            file {
-              url
+            slug
+            intro: introSentence {
+              introSentence
+            }
+            posterColor
+            posterImage {
+              title
+              file {
+                url
+              }
             }
           }
         }

--- a/src/templates/service.js
+++ b/src/templates/service.js
@@ -102,6 +102,23 @@ export const pageQuery = graphql`
           }
           posterColor
         }
+        ... on ContentfulNonTemplatedCaseStudyV2 {
+          title
+          slug
+          intro: introSentence {
+            introSentence
+          }
+          posterImage {
+            title
+            fluid(maxWidth: 600) {
+              ...GatsbyContentfulFluid_withWebp
+            }
+            file {
+              url
+            }
+          }
+          posterColor
+        }
       }
       caseStudies {
         ... on ContentfulTemplatedCaseStudy {


### PR DESCRIPTION
## Description - [Make doctorlink case study the featured design case study](https://trello.com/c/8afMpwd9/564-make-doctorlink-case-study-the-featured-design-case-study-on-the-design-landing-page-related-case-study-on-other-design-case-stu)

put a short summary of what you did here:
- [x] Add missing `h1` on doctor link
- [x] Allow services.caseStudies to accept a case study of type ContentfulNonTemplatedCaseStudyV2.
I added DoctorLink in that array in Contentul (which only has Canon so far). By updating to index 1 it renders the DoctorLink CS. If the intention is to always render 1 case study on Top, I suggest to leave index 0 and have a limitiation of `no more than 1` in Contentful, like it's done for related case studies.
I suggest that PR not to be merged before we have a chance to discuss this with the team.

nb:
Speaking of `services.relatedCaseStudy`, I tried and am still trying to add ContentfulNonTemplatedCaseStudyV2 as a fragment within the query. It's not having it. In Contentful related case study is set-up to potentially be of type ContentfulNonTemplatedCaseStudyV2 so I'm not sure what the problem is. I cannot update in Contentful as it would also update in production unlike services.caseStudies where I can control what to display with the index. It's out of the scope of the ticket but it makes sense to tackle related case Studies as v2 so we can also use them.

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
