### PR TITLE
Make case study card images full width of container

### DIFF
--- a/src/components/Common/animatedLink.js
+++ b/src/components/Common/animatedLink.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
 import styled from 'styled-components'
 import remcalc from 'remcalc'
-import breakpoint from 'styled-components-breakpoint'
 import Flex from 'styled-flex-component'
 
 export const AnimatedLink = styled(Link)`
@@ -23,23 +22,13 @@ AnimatedLink.propType = {
 
 export const PosterImage = styled(Flex)`
   background: #${props => props.color};
-
   max-width: 100%;
 
-  ${breakpoint('tablet')`
-    height: 528px;
-  `}
-  ${breakpoint('desktop')`
-    width: 100%;
-    height: 473px;
-  `}
   > img {
     align-self: center;
     justify-self: center;
-    ${breakpoint('tablet')`
-      max-width: 100%
-      width: 100%;
-    `}
+    max-width: 100%
+    width: 100%;
   }
 `
 

--- a/src/components/Homepage/services.js
+++ b/src/components/Homepage/services.js
@@ -33,19 +33,9 @@ const AnimatedLink = styled(Link)`
   }
 `
 
-const PosterImage = styled.div`
+const ImageWrapper = styled.div`
   background: #${props => props.color};
-
   max-width: 100%;
-
-  ${breakpoint('tablet')`
-    height: 45vw;
-  `}
-
-  ${breakpoint('desktop')`
-    width: 475px;
-    height: 473px;
-  `}
 `
 
 const MasonryContainer = styled(Col)`
@@ -137,9 +127,9 @@ const Services = ({ services }) => (
                       </CardTitle>
                     </section>
                   </CardHeader>
-                  <PosterImage color={service.caseStudies[0].posterColor}>
+                  <ImageWrapper color={service.caseStudies[0].posterColor}>
                     <Image image={service.caseStudies[0].posterImage} />
-                  </PosterImage>
+                  </ImageWrapper>
                 </section>
               </AnimatedLink>
               <Padding bottom={{ smallPhone: 4, smallTablet: 5 }} />

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -1161,6 +1161,8 @@ exports[`Storyshots AnimatedLink AnimatedLink 1`] = `
   -ms-flex-item-align: center;
   align-self: center;
   justify-self: center;
+  max-width: 100%;
+  width: 100%;
 }
 
 .c1 {
@@ -1171,26 +1173,6 @@ exports[`Storyshots AnimatedLink AnimatedLink 1`] = `
 
 .c1 > div {
   max-width: 19.375rem;
-}
-
-@media (min-width:56.3125em) {
-  .c2 {
-    height: 528px;
-  }
-}
-
-@media (min-width:74.8125em) {
-  .c2 {
-    width: 100%;
-    height: 473px;
-  }
-}
-
-@media (min-width:56.3125em) {
-  .c2 > img {
-    max-width: 100%;
-    width: 100%;
-  }
 }
 
 <a


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/D1mmWx93/569-doctorlink-case-study-card)

- remove magic numbers for image dimensions
- resolve confusing naming for `PosterImage` in code base
