### PR TITLE
Fix-react-warning-proptypes-title-required

### DIFF
--- a/src/components/Common/Anchor.js
+++ b/src/components/Common/Anchor.js
@@ -1,18 +1,12 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
 import ExternalAnchor from './ExternalAnchor'
 
-const Anchor = ({ to, href, activeClassName, ...props }) => {
-  if (to != null) {
-    return <Link to={to} activeClassName={activeClassName} {...props} />
-  } else {
-    return <ExternalAnchor href={href} {...props} />
-  }
-}
-
-Anchor.propTypes = {
-  title: PropTypes.string.isRequired
-}
+const Anchor = ({ to, href, activeClassName, ...props }) =>
+  to != null ? (
+    <Link to={to} activeClassName={activeClassName} {...props} />
+  ) : (
+    <ExternalAnchor href={href} {...props} />
+  )
 
 export default Anchor

--- a/src/components/Common/Anchor.js
+++ b/src/components/Common/Anchor.js
@@ -2,11 +2,12 @@ import React from 'react'
 import { Link } from 'gatsby'
 import ExternalAnchor from './ExternalAnchor'
 
-const Anchor = ({ to, href, activeClassName, ...props }) =>
-  to != null ? (
-    <Link to={to} activeClassName={activeClassName} {...props} />
-  ) : (
-    <ExternalAnchor href={href} {...props} />
-  )
+const Anchor = ({ to, href, activeClassName, ...props }) => {
+  if (to != null) {
+    return <Link to={to} activeClassName={activeClassName} {...props} />
+  } else {
+    return <ExternalAnchor href={href} {...props} />
+  }
+}
 
 export default Anchor

--- a/src/components/Common/ExternalAnchor.js
+++ b/src/components/Common/ExternalAnchor.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 const ExternalAnchor = ({ children, openInNewWindow = true, ...props }) => {
   return (
@@ -11,10 +10,6 @@ const ExternalAnchor = ({ children, openInNewWindow = true, ...props }) => {
       {children}
     </a>
   )
-}
-
-ExternalAnchor.propTypes = {
-  title: PropTypes.string.isRequired
 }
 
 export default ExternalAnchor

--- a/src/components/Common/StyledLink.js
+++ b/src/components/Common/StyledLink.js
@@ -96,10 +96,16 @@ const StyledLink = ({ external, to, href, children, ...props }) => {
       }
     : {}
 
-  const redirectProps = to ? { to } : { as: 'a', href }
+  if (to) {
+    return (
+      <Anchor {...externalProps} to={to} {...props}>
+        {children}
+      </Anchor>
+    )
+  }
 
   return (
-    <Anchor {...externalProps} {...props} {...redirectProps}>
+    <Anchor {...externalProps} as="a" href={href} {...props}>
       {children}
     </Anchor>
   )

--- a/src/components/Common/StyledLink.js
+++ b/src/components/Common/StyledLink.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
 import styled, { css } from 'styled-components'
 import remcalc from 'remcalc'
@@ -11,11 +10,11 @@ export const StyledLinkCss = css`
   margin-bottom: ${remcalc(24)};
   margin-left: ${remcalc(-6)};
   line-height: ${remcalc(24)};
-  color: ${props => props.theme.colors.text};
+  color: ${({ theme }) => theme.colors.text};
   font-weight: 700;
   position: relative;
   display: inline-block;
-  transition: all ${props => props.theme.animations.fast} ease-out;
+  transition: all ${({ theme }) => theme.animations.fast} ease-out;
   transition-property: background, color;
 
   &:after {
@@ -24,58 +23,58 @@ export const StyledLinkCss = css`
     height: ${remcalc(2)};
     width: 100%;
     margin-top: ${remcalc(6)};
-    background: ${props => props.theme.colors.text};
+    background: ${({ theme }) => theme.colors.text};
     box-sizing: border-box;
     ${is('noafter')`
       content: none;
     `}
     ${is('reverse')`
-      background: ${props => props.theme.colors.white};
+      background: ${({ theme }) => theme.colors.white};
   `};
   }
 
   &:hover {
-    background: ${props => props.theme.colors.greyBg};
-    color: ${props => props.theme.colors.text};
+    background: ${({ theme }) => theme.colors.greyBg};
+    color: ${({ theme }) => theme.colors.text};
   }
 
   &:focus {
     background: transparent;
-    outline: ${remcalc(4)} solid ${props => props.theme.colors.vibrant};
-    color: ${props => props.theme.colors.text};
+    outline: ${remcalc(4)} solid ${({ theme }) => theme.colors.vibrant};
+    color: ${({ theme }) => theme.colors.text};
   }
 
   &:active {
     outline: none;
     background: #00edbf;
-    color: ${props => props.theme.colors.text};
+    color: ${({ theme }) => theme.colors.text};
 
     &:after {
-      background: ${props => props.theme.colors.text};
+      background: ${({ theme }) => theme.colors.text};
     }
   }
 
   ${is('reverse')`
-    color: ${props => props.theme.colors.white};
+    color: ${({ theme }) => theme.colors.white};
 
     &:hover {
-      background: ${props => props.theme.colors.black};
-      color: ${props => props.theme.colors.white};
+      background: ${({ theme }) => theme.colors.black};
+      color: ${({ theme }) => theme.colors.white};
     }
 
     &:focus {
       background: transparent;
-      outline: ${remcalc(4)} solid ${props => props.theme.colors.vibrant};
-      color: ${props => props.theme.colors.white};
+      outline: ${remcalc(4)} solid ${({ theme }) => theme.colors.vibrant};
+      color: ${({ theme }) => theme.colors.white};
     }
 
     &:active {
       outline: none;
       background: #00edbf;
-      color: ${props => props.theme.colors.text};
+      color: ${({ theme }) => theme.colors.text};
 
       &:after {
-        background: ${props => props.theme.colors.text};
+        background: ${({ theme }) => theme.colors.text};
       }
     }
   `};
@@ -96,23 +95,14 @@ const StyledLink = ({ external, to, href, children, ...props }) => {
         rel: 'noopener noreferrer'
       }
     : {}
-  if (to) {
-    return (
-      <Anchor {...externalProps} to={to} {...props}>
-        {children}
-      </Anchor>
-    )
-  }
+
+  const redirectProps = to ? { to } : { as: 'a', href }
 
   return (
-    <Anchor {...externalProps} as="a" href={href} {...props}>
+    <Anchor {...externalProps} {...props} {...redirectProps}>
       {children}
     </Anchor>
   )
-}
-
-StyledLink.propTypes = {
-  title: PropTypes.string.isRequired
 }
 
 export default StyledLink

--- a/src/components/Common/animatedLink.js
+++ b/src/components/Common/animatedLink.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { Link } from 'gatsby'
 import styled from 'styled-components'
 import remcalc from 'remcalc'
@@ -6,7 +5,7 @@ import Flex from 'styled-flex-component'
 
 export const AnimatedLink = styled(Link)`
   > section {
-    transition: all ${props => props.theme.animations.normal} ease;
+    transition: all ${({ theme }) => theme.animations.normal} ease;
   }
 
   &:hover {
@@ -16,12 +15,8 @@ export const AnimatedLink = styled(Link)`
   }
 `
 
-AnimatedLink.propType = {
-  title: PropTypes.string.isRequired
-}
-
 export const PosterImage = styled(Flex)`
-  background: #${props => props.color};
+  background: #${({ color }) => color};
   max-width: 100%;
 
   > img {


### PR DESCRIPTION
## Description
We had all these warnings related to propTypes title in multiple pages.
Links seem to work without it so I'm not sure why it didn't show in the first place

put a short summary of what you did here
- Remove title as required propType and remove propType as a whole for StyledLink component
- Refactor StyledLink.js as a whole.
- Remove title as required propType and remove propType as a whole for ExternalAnchor component

## Review template

- [ ] checked that this PR resolves the spec provided from trello / this description
- [ ] ensured that this PR does not introduce any obvious bugs
