### PR TITLE
spike: prefix socialLogo with https

### DIFF
--- a/src/components/Common/Head.js
+++ b/src/components/Common/Head.js
@@ -28,7 +28,15 @@ const Head = ({ page }) => {
         }`
 
         const description = page.seoMetaDescription || page.seoDescription
-        const imageUrl = page.socialLogo || `${siteUrl}${image}`
+
+        /**
+         * Contentful doesn't give us https: in the image urls so
+         * we have to prefix them here for twitter et al to pick
+         * up the image properly
+         */
+        const imageUrl = page.socialLogo
+          ? `https://${page.socialLogo}`
+          : `${siteUrl}${image}`
 
         return (
           <Helmet>


### PR DESCRIPTION
This is a bit of spike but I'm trying to work out if  the urls we get from contentful are causing twitter et al to not properly render them in cards. 

image asset url from contentful: `//image.ctfassets.com.....`
^ this doesn't render properly in twitter cards when set as `og:image` but `https://yld.io/image/logo.png` renders fine....