### PR TITLE
add query param to get font-display: swap in google fonts

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -24,7 +24,7 @@ const HTML = ({
           href="https://fonts.gstatic.com/"
         />
         <link
-          href="https://fonts.googleapis.com/css?family=PT+Mono|Roboto:400,500,700"
+          href="https://fonts.googleapis.com/css?family=PT+Mono|Roboto:400,500,700&display=swap"
           rel="stylesheet"
         />
         {headComponents}


### PR DESCRIPTION
Google Fonts by default does not give us `font-display: swap` in it's style sheets, this gets flagged in lighthouse auditing: 

![image](https://user-images.githubusercontent.com/7108120/61614636-d4656f00-ac96-11e9-8d60-9ba16ae6c230.png)

More details here: https://developers.google.com/web/updates/2016/02/font-display?utm_source=lighthouse&utm_medium=devtools

This PR simply passes the query param `&display=swap` to the url we use to get the fonts in the first place which then in turn gets us the font-display in all of the fonts downloaded
