### PR TITLE
added fluid query to Speciality GQL query for grid images

### DIFF
--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -116,6 +116,9 @@ export const pageQuery = graphql`
           url
           fileName
         }
+        fluid(maxWidth: 250) {
+          ...GatsbyContentfulFluid_withWebp_noBase64
+        }
       }
       trainingIntroText {
         nodeType


### PR DESCRIPTION
## Description - [Trello ticket 602](https://trello.com/c/z697TCHO/602-seo-template-investigate-logo-grid)

Added 
```   
 fluid(maxWidth: 250) {
          ...GatsbyContentfulFluid_withWebp_noBase64
        }
```
to the GQL query for speciality clients grid.

Now looks like this: 

![Screenshot from 2019-07-29 12-08-46](https://user-images.githubusercontent.com/31079643/62044099-024c3580-b1fa-11e9-9459-5000e9daa9ba.png)


## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
