### PR TITLE
Fixed logic for YLD logo colours on speciality / service pages

### DIFF
--- a/src/components/Header/TopNav/LogoLink.js
+++ b/src/components/Header/TopNav/LogoLink.js
@@ -12,6 +12,7 @@ import {
   getIsServicePage,
   getService
 } from '../navLinksHelper'
+import themeHelper from '../../../utils/theme'
 
 const StyledLink = styled(Link)`
   height: ${remcalc(48)};
@@ -31,7 +32,7 @@ const LogoLink = ({ path = '/' }) => {
   const service = isSpecialityPage ? getService(path) : serviceTitle
   const speciality = isSpecialityPage ? getSpeciality(path) : null
 
-  let metaFillColor = '#fff'
+  let metaFillColor = themeHelper.colors.white
 
   if (isServicePage) {
     metaFillColor = logoColors['default']

--- a/src/components/Header/TopNav/LogoLink.js
+++ b/src/components/Header/TopNav/LogoLink.js
@@ -31,10 +31,16 @@ const LogoLink = ({ path = '/' }) => {
   const service = isSpecialityPage ? getService(path) : serviceTitle
   const speciality = isSpecialityPage ? getSpeciality(path) : null
 
-  let originalFillColor = isSpecialityPage
-    ? logoColors[service][speciality]
-    : logoColors['default']
-  const [fillColor, setFillColor] = useState(originalFillColor)
+  let metaFillColor = '#fff'
+
+  if (isServicePage) {
+    metaFillColor = logoColors['default']
+  }
+  if (isSpecialityPage && logoColors[service][speciality]) {
+    metaFillColor = logoColors[service][speciality]
+  }
+
+  const [fillColor, setFillColor] = useState(metaFillColor)
 
   return (
     <Fragment>
@@ -47,7 +53,7 @@ const LogoLink = ({ path = '/' }) => {
               logoColors[isServicePage ? 'defaultHover' : 'specialityHover']
             )
           }
-          onMouseLeave={() => setFillColor(originalFillColor)}
+          onMouseLeave={() => setFillColor(metaFillColor)}
         >
           <ServiceSpecialityLogo
             fillColor={fillColor}

--- a/src/components/Header/TopNav/LogoLink.js
+++ b/src/components/Header/TopNav/LogoLink.js
@@ -12,7 +12,7 @@ import {
   getIsServicePage,
   getService
 } from '../navLinksHelper'
-import themeHelper from '../../../utils/theme'
+import theme from '../../../utils/theme'
 
 const StyledLink = styled(Link)`
   height: ${remcalc(48)};
@@ -32,16 +32,16 @@ const LogoLink = ({ path = '/' }) => {
   const service = isSpecialityPage ? getService(path) : serviceTitle
   const speciality = isSpecialityPage ? getSpeciality(path) : null
 
-  let metaFillColor = themeHelper.colors.white
+  let originalFillColor = theme.colors.white
 
   if (isServicePage) {
-    metaFillColor = logoColors['default']
+    originalFillColor = logoColors['default']
   }
   if (isSpecialityPage && logoColors[service][speciality]) {
-    metaFillColor = logoColors[service][speciality]
+    originalFillColor = logoColors[service][speciality]
   }
 
-  const [fillColor, setFillColor] = useState(metaFillColor)
+  const [fillColor, setFillColor] = useState(originalFillColor)
 
   return (
     <Fragment>
@@ -54,7 +54,7 @@ const LogoLink = ({ path = '/' }) => {
               logoColors[isServicePage ? 'defaultHover' : 'specialityHover']
             )
           }
-          onMouseLeave={() => setFillColor(metaFillColor)}
+          onMouseLeave={() => setFillColor(originalFillColor)}
         >
           <ServiceSpecialityLogo
             fillColor={fillColor}

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -8906,6 +8906,7 @@ exports[`Storyshots Header TopNavbar - Speciality TopNavBar 1`] = `
             stroke="none"
           >
             <rect
+              fill="#fff"
               height="54"
               id="Logo-rectangle"
               width="54"


### PR DESCRIPTION
## Description - [Trello ticket 601](https://trello.com/c/I9qS37iS/601-seo-template-add-default-logo-fill-colour)

Rejigged the logic of providing the logo colour from two options (isService and isSpeciality) to three options (isService, isSpecialityWithOwnColour, isSpecialityWithoutOwnColour)

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
