### PR TITLE
Fixed JoinUs job ops redirecting to undefined

### DIFF
--- a/src/components/JoinUs/ViewOpenPositions.js
+++ b/src/components/JoinUs/ViewOpenPositions.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Padding } from 'styled-components-spacing'
 import { Grid, Row, Col } from '../grid'
 import { SectionTitle, BodyPrimary } from '../Typography'
-import FakeLink from '../Common/StyledLink'
+import { FakeLink } from '../Common/StyledLink'
 
 const FixedWidthBodyPrimary = styled(BodyPrimary)`
   max-width: ${remcalc(525)};


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/mtVRbKSR/604-join-us-see-all-jobs-redirects-to-undefined)

We were importing the default export from StyledLink, I believe the `react scroll to` module we're using fires the react synthetic event after its finished its initial scrolling behaviour so an anchor click will go to its href which is undefined thus we saw 404!
