### PR TITLE
training is now optional on speciality page (also minor CSS fix)

### DIFF
--- a/src/components/Common/animatedLink.js
+++ b/src/components/Common/animatedLink.js
@@ -22,7 +22,7 @@ export const PosterImage = styled(Flex)`
   > img {
     align-self: center;
     justify-self: center;
-    max-width: 100%
+    max-width: 100%;
     width: 100%;
   }
 `

--- a/src/templates/speciality-component.js
+++ b/src/templates/speciality-component.js
@@ -4,7 +4,8 @@ import Ajv from 'ajv'
 import {
   communitySchema,
   projectsSchema,
-  clientSchema
+  clientSchema,
+  trainingSchema
 } from './speciality/schemas'
 
 import {
@@ -42,6 +43,7 @@ export const SpecialityView = props => {
   const validateCommunity = ajv.compile(communitySchema)
   const validateProjects = ajv.compile(projectsSchema)
   const validateClients = ajv.compile(clientSchema)
+  const validateTraining = ajv.compile(trainingSchema)
 
   const {
     title,
@@ -62,6 +64,7 @@ export const SpecialityView = props => {
   const renderProjectsSection =
     validateProjects(relatedProjects) || validateClients(clients)
   const renderCommunitySection = validateCommunity(flattenedSpeciality)
+  const renderTrainingSection = validateTraining(flattenedSpeciality)
 
   const renderTalksSection = talks && talks.length > 0
   const renderBooksSection = books && books.length > 0
@@ -81,7 +84,9 @@ export const SpecialityView = props => {
           clients={clients}
         />
       )}
-      <TrainingSection speciality={flattenedSpeciality} />
+      {renderTrainingSection && (
+        <TrainingSection speciality={flattenedSpeciality} />
+      )}
       {renderCommunitySection && <CommunitySection {...flattenedSpeciality} />}
       <EventSection
         events={specialityEvents}

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -108,6 +108,20 @@ export const pageQuery = graphql`
             }
           }
         }
+        ... on ContentfulNonTemplatedCaseStudyV2 {
+          title
+          slug
+          posterColor
+          introSentence {
+            introSentence
+          }
+          posterImage {
+            title
+            file {
+              url
+            }
+          }
+        }
       }
       clients {
         id

--- a/src/templates/speciality/schemas.js
+++ b/src/templates/speciality/schemas.js
@@ -19,6 +19,17 @@ const communitySchema = {
   required: ['title', 'communityText']
 }
 
+const trainingSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    trainingIntroText: {
+      type: 'string'
+    }
+  },
+  required: ['trainingIntroText']
+}
+
 const projectsSchema = {
   definitions: {},
   $schema: 'http://json-schema.org/draft-07/schema#',
@@ -176,4 +187,4 @@ const clientSchema = {
   }
 }
 
-export { communitySchema, projectsSchema, clientSchema }
+export { communitySchema, projectsSchema, clientSchema, trainingSchema }


### PR DESCRIPTION
## Description - [Trello ticket 605](https://trello.com/c/UMyBVTgs/605-make-training-section-on-speciality-seo-page-optional)

Made Training section on the Speciality Page optional. 
Added GQL query to query for CaseStudyV2
Minor CSS fix (missing semicolon) to enable `width:100%`

Note: the Training Schema is stupidly simple and assumes that if there's no training intro line, there's no training section. Happy to make it more detailed, but this seemed to be sufficient to do the job.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
