### PR TITLE
change the blog link

### DIFF
--- a/src/components/Blog/MediumPostPreview.js
+++ b/src/components/Blog/MediumPostPreview.js
@@ -135,7 +135,7 @@ const MediumPostPreview = ({
   const imageUrl = `https://cdn-images-1.medium.com/max/1000/${
     virtuals.previewImage.imageId
   }`
-  const postUrl = `https://medium.com/yld-engineering-blog/${uniqueSlug}`
+  const postUrl = `https://medium.com/yld-blog/${uniqueSlug}`
   const authorUrl = `https://medium.com/@${author.username}`
 
   const image = {

--- a/src/components/Common/BlogListing.js
+++ b/src/components/Common/BlogListing.js
@@ -10,7 +10,7 @@ const BlogListing = ({ title, description, posts }) => {
     ({ id, title, uniqueSlug, firstPublishedAt }) => ({
       id,
       title,
-      href: `https://medium.com/yld-engineering-blog/${uniqueSlug}`,
+      href: `https://medium.com/yld-blog/${uniqueSlug}`,
       body: format(new Date(firstPublishedAt), 'MMMM DD[,] dddd')
     })
   )

--- a/src/components/Footer/links.js
+++ b/src/components/Footer/links.js
@@ -25,7 +25,7 @@ const social = [
   },
   {
     label: 'Medium',
-    to: 'https://medium.com/yld-engineering-blog',
+    to: 'https://medium.com/yld-blog',
     img: medium
   },
   {

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -63,7 +63,7 @@ const DescriptionMediumLink = styled(Anchor)`
 
 const BlogPage = ({ data: { allMediumPost: mediumContent } }) => {
   const mediumPosts = mediumContent.edges || []
-  const mediumLink = 'https://medium.com/yld-engineering-blog'
+  const mediumLink = 'https://medium.com/yld-blog'
 
   return (
     <Layout>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -2054,7 +2054,7 @@ exports[`Storyshots Blog Listing Blog Listing 1`] = `
               className="c9"
             >
               <a
-                href="https://medium.com/yld-engineering-blog/security-trivia-series-understanding-csps-reporting-68d885596686"
+                href="https://medium.com/yld-blog/security-trivia-series-understanding-csps-reporting-68d885596686"
                 onClick={[Function]}
                 rel="noopener noreferrer"
                 target="_blank"
@@ -2077,7 +2077,7 @@ exports[`Storyshots Blog Listing Blog Listing 1`] = `
               className="c9"
             >
               <a
-                href="https://medium.com/yld-engineering-blog/serverless-its-not-all-a-faas-9de3d8187ba3"
+                href="https://medium.com/yld-blog/serverless-its-not-all-a-faas-9de3d8187ba3"
                 onClick={[Function]}
                 rel="noopener noreferrer"
                 target="_blank"
@@ -2100,7 +2100,7 @@ exports[`Storyshots Blog Listing Blog Listing 1`] = `
               className="c9"
             >
               <a
-                href="https://medium.com/yld-engineering-blog/under-the-with-kubernetes-c1ea1a82c61f"
+                href="https://medium.com/yld-blog/under-the-with-kubernetes-c1ea1a82c61f"
                 onClick={[Function]}
                 rel="noopener noreferrer"
                 target="_blank"


### PR DESCRIPTION
## Description - [614](https://trello.com/c/eOvF4uGP/614-change-the-base-link-we-use-to-construct-the-url-to-each-post)

removes engineering word from the urls.
replace 'https://medium.com/yld-engineering-blog' with 'https://medium.com/yld-blog'

## Checklist

- [x] checked that this PR resolves the spec provided from trello / this description

