### PR TITLE
remove twitter:img and twitter:card tag from head

### DIFF
--- a/src/components/Common/Head.js
+++ b/src/components/Common/Head.js
@@ -51,9 +51,7 @@ const Head = ({ page }) => {
             <meta property="og:url" content={siteUrl} />
 
             {/* Twitter */}
-            <meta name="twitter:card" content="summary" />
             <meta name="twitter:site" content="yldio" />
-            <meta name="twitter:img" content={imageUrl} />
 
             <link rel="image_src" type="image/png" href={imageUrl} />
           </Helmet>


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/G18faAEA/378-fix-hero-images-when-posting-links-of-the-website-on-social-media)

Previously this was working and now twitter doesn't seem to want to pick up the images for case studies... removing these tags as og tags should  suffice.

These two tags fallback to their corresponding `og` tags so we can remove them. 

