### PR TITLE
add https to og:image url generation

### DIFF
--- a/src/components/Common/Head.js
+++ b/src/components/Common/Head.js
@@ -29,8 +29,13 @@ const Head = ({ page }) => {
 
         const description = page.seoMetaDescription || page.seoDescription
 
+        /**
+         * Contentful doesn't give us https: in the image urls so
+         * we have to prefix them here for twitter et al to pick
+         * up the image properly
+         */
         const imageUrl = page.socialLogo
-          ? page.socialLogo
+          ? `https://${page.socialLogo}`
           : `${siteUrl}${image}`
 
         return (


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/G18faAEA/378-fix-hero-images-when-posting-links-of-the-website-on-social-media)

This PR puts back the `https://` we previously had as I don't believe twitter et al can read urls without the protocol
