### PR TITLE
607-footer-yld-offices-line-breaks

### DIFF
--- a/src/components/Footer/Office.js
+++ b/src/components/Footer/Office.js
@@ -5,7 +5,9 @@ import PaddedCol from '../../components/AboutUs/PaddedCol'
 import { Subtitle, BodyPrimary } from '../../components/Typography'
 
 const StyledBodyPrimary = styled(BodyPrimary).attrs({ noPadding: true })`
-  color: ${props => props.theme.colors.white};
+  color: ${({ theme }) => theme.colors.white};
+  padding-top: ${({ theme, hasPaddingTop }) =>
+    theme.space[hasPaddingTop ? 3 : 0]};
   opacity: 0.5;
 `
 
@@ -16,14 +18,20 @@ const Office = ({ name, telephone, email, streetAddress }) => (
       {streetAddress.map(address => (
         <StyledBodyPrimary key={address}>{address}</StyledBodyPrimary>
       ))}
-      <StyledBodyPrimary itemProp="telephone">{telephone}</StyledBodyPrimary>
-      {email ? (
-        <StyledBodyPrimary>
+
+      {telephone && (
+        <StyledBodyPrimary itemProp="telephone" hasPaddingTop={telephone}>
+          {telephone}
+        </StyledBodyPrimary>
+      )}
+
+      {email && (
+        <StyledBodyPrimary hasPaddingTop={email && !telephone}>
           <a href={`mailto:${email}`} title={`Email yld ${name} Office`}>
             {email}
           </a>
         </StyledBodyPrimary>
-      ) : null}
+      )}
     </Padding>
   </PaddedCol>
 )

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -65,21 +65,29 @@ const getBackgroundColor = ({ pathname, contactUsBg, is404 = false }) => {
   )
 }
 
+const footerData = {
+  getInTouchTitle: "We're here to help",
+  getInTouchText:
+    'Our experts work with you to understand your goals and help you build the capabilities you need to succeed',
+  getInTouchCtaText: 'Contact us',
+  findUsTitle: 'Find us'
+}
+
 const Footer = ({ contactUsBg, is404 }) => (
   <Fragment>
     <Location>
       {({ location: { pathname } }) =>
-        showGetInTouch(pathname) ? (
+        showGetInTouch(pathname) && (
           <Wrapper
             bgColor={getBackgroundColor({ pathname, is404, contactUsBg })}
           >
             <GetInTouch
-              title="We're here to help"
-              contactText="Our experts work with you to understand your goals and help you build the capabilities you need to succeed"
-              ctaText="Contact us"
+              title={footerData.getInTouchTitle}
+              contactText={footerData.getInTouchText}
+              ctaText={footerData.getInTouchCtaText}
             />
           </Wrapper>
-        ) : null
+        )
       }
     </Location>
     <GreyFooter>
@@ -88,7 +96,7 @@ const Footer = ({ contactUsBg, is404 }) => (
           <Row>
             <Col width={1}>
               <Padding bottom={3}>
-                <SectionTitle reverse>Find us</SectionTitle>
+                <SectionTitle reverse>{footerData.findUsTitle}</SectionTitle>
               </Padding>
             </Col>
           </Row>


### PR DESCRIPTION
## Description - [Trello ticket](link)

- [x] London - there should be an additional blank line space separating the postcode and the telephone number
Also refactored the code in Footer and Office.

Done in Contentful
- [x] Lisbon - (3rd floor left) can we carry this over on a new line
- [x] Porto - (3rd floor) can we carry this over onto a new line

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
