### PR TITLE
CMS Speciality Logo Colours

### DIFF
--- a/src/components/Header/TopNav/LogoLink.js
+++ b/src/components/Header/TopNav/LogoLink.js
@@ -7,8 +7,6 @@ import logo from '../../../images/logo_animated.gif'
 import HomepageSvg from '../../../images/yld-white.svg'
 import ServiceSpecialityLogo from '../../../images/service-speciality-logo'
 
-import { logoColors } from '../navLinksHelper'
-
 const StyledLink = styled(Link)`
   height: ${remcalc(48)};
   width: ${remcalc(48)};
@@ -24,44 +22,22 @@ const HomepageLogo = styled.img`
   margin-top: ${remcalc(6)};
 `
 
-const getLogoColors = ({ isSpecialityPage, slug }) => {
-  // This isn't very nice I know...
-  // In reality the specialitiesFills shouldn't be in the code
-  // but in contentful. If the content type doesn't have a fill hex
-  // set in the CMS then just fallback to white.
-  const fillColorInitial = isSpecialityPage
-    ? logoColors.specialitiesFills[slug] || logoColors.specialitiesFills.default
-    : logoColors['default']
-
-  const fillColorHover =
-    logoColors[isSpecialityPage ? 'specialityHover' : 'defaultHover']
-
-  const textColor =
-    logoColors[isSpecialityPage ? 'specialityText' : 'defaultText']
-
-  return {
-    fillColorInitial,
-    fillColorHover,
-    textColor
-  }
-}
-
 const StyledHomePageLink = styled.div`
   cursor: pointer;
 `
 
-const LogoLink = ({ slug, isServicePage, isSpecialityPage, isHomePage }) => {
-  const renderSvg = isServicePage || isSpecialityPage || isHomePage
-
-  const { fillColorInitial, fillColorHover, textColor } = getLogoColors({
-    isSpecialityPage,
-    slug
-  })
-
+const LogoLink = ({
+  isHomePage,
+  isServiceOrSpecialityPage,
+  fillColorInitial,
+  fillColorHover,
+  textColor
+}) => {
+  const isSvgLogo = isServiceOrSpecialityPage || isHomePage
   const [fillColor, setFillColor] = useState(fillColorInitial)
 
-  if (renderSvg) {
-    return isServicePage || isSpecialityPage ? (
+  if (isSvgLogo) {
+    return isServiceOrSpecialityPage ? (
       <StyledLink
         to="/"
         title="Return to Homepage"

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -2,12 +2,14 @@ import React from 'react'
 import styled from 'styled-components'
 import breakpoint from 'styled-components-breakpoint'
 import remcalc from 'remcalc'
-
+import find from 'lodash.find'
 import { StaticQuery, graphql } from 'gatsby'
+
 import LogoLink from './LogoLink'
 import ServiceLink from './ServiceLink'
 import OuterAnchorItem from './OuterAnchorItem'
 import Dropdown from './Dropdown'
+import { logoColors } from '../navLinksHelper'
 
 const StyledTopNavContainer = styled.nav`
   display: flex;
@@ -36,6 +38,8 @@ const TopNavList = styled.ul`
 `
 
 const getSlugs = (arr = []) => arr.map(({ slug }) => slug).filter(i => i)
+
+const getColor = (arr, slug) => find(arr, { slug: slug }).logoColour
 
 const getSpecialitiesToServices = (services = []) =>
   services.reduce((acc, { slug, ...rest }) => {
@@ -94,6 +98,7 @@ const TopNavBranding = ({ path, slug }) => (
         specialities: allContentfulSpeciality {
           nodes {
             slug
+            logoColour
           }
         }
       }
@@ -113,14 +118,25 @@ const TopNavBranding = ({ path, slug }) => (
         ? slug
         : getService({ slug, map: specialitiesToServicesMap })
 
+      const fillColorInitial = isSpecialityPage
+        ? getColor(specialities.nodes, slug) ||
+          logoColors.specialitiesFillDefault
+        : logoColors['default']
+
+      const fillColorHover =
+        logoColors[isSpecialityPage ? 'specialityHover' : 'defaultHover']
+
+      const textColor =
+        logoColors[isSpecialityPage ? 'specialityText' : 'defaultText']
+
       return (
         <StyledLinksContainer>
           <LogoLink
-            isSpecialityPage={isSpecialityPage}
-            isServicePage={isServicePage}
             isHomePage={isHomePage}
-            path={path}
-            slug={slug}
+            isServiceOrSpecialityPage={isServicePage || isSpecialityPage}
+            fillColorInitial={fillColorInitial}
+            fillColorHover={fillColorHover}
+            textColor={textColor}
           />
           <ServiceLink
             isSpecialityPage={isSpecialityPage}

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -142,8 +142,6 @@ const TopNavBranding = ({ path, slug }) => (
             isSpecialityPage={isSpecialityPage}
             isServicePage={isServicePage}
             service={service}
-            slug={slug}
-            path={path}
           />
         </StyledLinksContainer>
       )

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -39,7 +39,7 @@ const TopNavList = styled.ul`
 
 const getSlugs = (arr = []) => arr.map(({ slug }) => slug).filter(i => i)
 
-const getColor = (arr, slug) => (find(arr, { slug }) || {}).logoColor
+const getColour = (arr, slug) => find((arr, { slug }) || {}).logoColour
 
 const getSpecialitiesToServices = (services = []) =>
   services.reduce((acc, { slug, ...rest }) => {
@@ -119,7 +119,7 @@ const TopNavBranding = ({ path, slug }) => (
         : getService({ slug, map: specialitiesToServicesMap })
 
       const fillColorInitial = isSpecialityPage
-        ? getColor(specialities.nodes, slug) ||
+        ? getColour(specialities.nodes, slug) ||
           logoColors.specialitiesFillDefault
         : logoColors['default']
 

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -39,7 +39,7 @@ const TopNavList = styled.ul`
 
 const getSlugs = (arr = []) => arr.map(({ slug }) => slug).filter(i => i)
 
-const getColor = (arr, slug) => find(arr, { slug: slug }).logoColour
+const getColor = (arr, slug) => (find(arr, { slug }) || {}).logoColor
 
 const getSpecialitiesToServices = (services = []) =>
   services.reduce((acc, { slug, ...rest }) => {

--- a/src/components/Header/TopNav/index.js
+++ b/src/components/Header/TopNav/index.js
@@ -39,7 +39,7 @@ const TopNavList = styled.ul`
 
 const getSlugs = (arr = []) => arr.map(({ slug }) => slug).filter(i => i)
 
-const getColour = (arr, slug) => find((arr, { slug }) || {}).logoColour
+const getColour = (arr, slug) => (find(arr, { slug }) || {}).logoColour
 
 const getSpecialitiesToServices = (services = []) =>
   services.reduce((acc, { slug, ...rest }) => {

--- a/src/components/Header/navLinksHelper.js
+++ b/src/components/Header/navLinksHelper.js
@@ -17,17 +17,7 @@ const logoColors = {
   defaultHover: '#8e8e8e',
   specialityText: theme.colors.blueBg,
   specialityHover: theme.colors.white,
-  specialitiesFills: {
-    default: theme.colors.white,
-    'node-js': '#52FFAC',
-    graphql: '#EB008B',
-    'vue-js': '#039328',
-    'react-js': '#0BDDF9',
-    'react-native': '#968CEA',
-    kubernetes: '#29EFEF',
-    amp: '#0097E2',
-    'data-analysis': '#00B7FF'
-  }
+  specialitiesFillDefault: theme.colors.white
 }
 
 const servicesList = Object.keys(specialitiesMap)

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -284,6 +284,7 @@ export const pageQuery = graphql`
           url
         }
       }
+      logoColour
       contactText
     }
 


### PR DESCRIPTION
## Description - [617](https://trello.com/c/tfnmREtE/617-create-functionality-for-adding-speciality-logo-fill-colours-via-cms)

Put a short summary of what you did here
Logo colour was already added a non required field in Contentful `Speciality` but not always filled.

- [x] added all the colors of our live specialities in Contentful.
- [x] removed specialities colors from codebase
- [x] update logic to retrieve specialities colors from Contentful.
- [x] refactor it all so it's nicer and more explicit

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
