### PR TITLE
Make sure gif logo and landing page logo are the same dimensions

### DIFF
--- a/src/components/Header/TopNav/LogoLink.js
+++ b/src/components/Header/TopNav/LogoLink.js
@@ -55,7 +55,7 @@ const LogoLink = ({
 
   return (
     <Link to="/" title="Return to Homepage">
-      <img role="link" height="48" src={logo} alt="yld logo" />
+      <img role="link" width="49" src={logo} alt="yld logo" />
     </Link>
   )
 }


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/BNnaJaEE/628-landing-page-logo-white-on-navy-appears-smaller-than-non-landing-page-logo-black-on-white-black-on-white-is-the-correct-size)

Removed with width attribute in the gif logo and replaced it with height to match landing page logo
