### PR TITLE
Retrieve seoMetaData data within speciality template and pass to Head

### DIFF
--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -11,7 +11,7 @@ const Speciality = ({ data, location }) => {
 
   return (
     <Layout bgColor="blueBg" slug={slug} title={title} location={location}>
-      <Head page={speciality} />
+      <Head seoMetaData={speciality.seoMetaData} page={speciality} />
       <SpecialityView data={data} />
     </Layout>
   )
@@ -26,6 +26,9 @@ export const pageQuery = graphql`
       title
       seoTitle
       seoMetaDescription
+      seoMetaData {
+        ...SEOMetaFields
+      }
       seoText {
         nodeType
         content {


### PR DESCRIPTION
## Description - [SEO Meta Data - Specialities](https://trello.com/c/gxdKaRiV/643-seo-meta-data-specialities)

Put a short summary of what you did here:
- Populate all the specialities in Contentful with the new seoMetaData:
  entityTitle
  title: (Recommended Page Title - SEO title from YLD Full Pages list excel spreadsheet)
  description: current description within Contentful
  keywords: (Keyword Target from YLD Full Pages list excel spreadsheet)
- Retrieve seoMetaData data within speciality template and pass to Head

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
