### PR TITLE
Retrieve seoMetaData data within open source page and pass to Head

### DIFF
--- a/src/pages/open-source.js
+++ b/src/pages/open-source.js
@@ -25,8 +25,7 @@ const StyledHr = styled(Hr)`
 const OpenSource = ({ data, location }) => {
   const {
     contentfulOpenSourcePage: {
-      title,
-      seoDescription,
+      seoMetaData,
       featuredCaseStudy,
       statement,
       talksSectionImage,
@@ -85,7 +84,7 @@ const OpenSource = ({ data, location }) => {
 
   return (
     <Layout location={location} slug={'open-source'}>
-      <Head page={{ title, seoDescription }} />
+      <Head seoMetaData={seoMetaData} />
       <CaseStudyPreview isTop caseStudy={featuredCaseStudy} />
       <Statement as="h1">{statement}</Statement>
       <WhyOpenSource
@@ -155,6 +154,9 @@ const OpenSourcePage = props => (
         contentfulOpenSourcePage {
           title
           seoDescription
+          seoMetaData {
+            ...SEOMetaFields
+          }
           eventsSectionImage {
             id
             title


### PR DESCRIPTION
## Description - [SEO Meta Data - Open Source Page](https://trello.com/c/GF23kBdo/650-seo-meta-data-open-source-page)

Put a short summary of what you did here
Populate open source page with the new seoMetaData.
Retrieve seoMetaData data within open source page and pass to Head

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
