### PR TITLE
Retrieve seoMetaData data within privacy policy page and pass to Head

### DIFF
--- a/src/templates/policy.js
+++ b/src/templates/policy.js
@@ -32,25 +32,26 @@ const Section = styled.section`
 
 const renderParagraphs = content =>
   makeText(content).map(cont => <p key={cont.trim()}>{cont}</p>)
+
 const Policy = ({ data: { contentfulPolicy: policy }, location }) => {
+  const { seoMetaData, title, body, section } = policy
+
   return (
     <Layout location={location}>
-      <Head page={policy} />
+      <Head seoMetaData={seoMetaData} />
       <Padding top={4} bottom={5}>
         <Grid>
           <Row>
             <Col width={[1, 1, 1, 1 / 2]}>
               <Padding bottom={{ smallPhone: 2, phone: 2 }}>
-                <Title>{policy.title}</Title>
+                <Title>{title}</Title>
               </Padding>
             </Col>
             <Col>
-              {policy.body && policy.body.body && (
-                <Body>{renderParagraphs(policy.body.body)}</Body>
-              )}
-              {policy.section &&
-                policy.section.length &&
-                policy.section.map(({ title, content: { content } }) => (
+              {body && body.body && <Body>{renderParagraphs(body.body)}</Body>}
+              {section &&
+                section.length &&
+                section.map(({ title, content: { content } }) => (
                   <Section key={title}>
                     <SectionTitle>{title}</SectionTitle>
                     {renderParagraphs(content)}
@@ -79,6 +80,9 @@ export const pageQuery = graphql`
         content {
           content
         }
+      }
+      seoMetaData {
+        ...SEOMetaFields
       }
     }
   }


### PR DESCRIPTION
## Description - [SEO Meta Data - Policy](https://trello.com/c/CkY2De54/651-seo-meta-data-policy)

Put a short summary of what you did here
Populate privacy, cookie & data retention policy pages with the new seoMetaData.
Retrieve seoMetaData data within privacy policy page and pass to Head
Refactored a tiny bit privacy policy page

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
