### PR TITLE
654 - Update speciality events logic

### DIFF
--- a/src/components/Common/Events.js
+++ b/src/components/Common/Events.js
@@ -14,7 +14,7 @@ const noEventsMessage = title =>
 
 const getAllUpcomingEvents = events =>
   events
-    .filter(({ node: { date } }) => isAfter(date, endOfYesterday()))
+    .filter(({ date }) => isAfter(date, endOfYesterday()))
     .sort((a, b) => (a.date <= b.date ? -1 : 1))
     .slice(0, 5)
 
@@ -38,8 +38,8 @@ const StyledBodyPrimary = styled(BodyPrimary)`
 `
 
 const EventSection = ({ events, title, description }) => {
-  const displayedEvents = events.length ? getAllUpcomingEvents(events) : []
-  const hasEvents = !!displayedEvents.length
+  const upcomingEvents = events.length ? getAllUpcomingEvents(events) : []
+  const hasEvents = !!upcomingEvents.length
 
   return (
     <Grid>
@@ -68,21 +68,19 @@ const EventSection = ({ events, title, description }) => {
           <Col width={[1, 1, 1, 1, 5 / 12]}>
             {hasEvents ? (
               <ul>
-                {displayedEvents.map(
-                  ({ node: { id, eventTitle, date, linkToEvent } }) => (
-                    <li key={`${id}`}>
-                      <Subtitle noPaddingBottom>
-                        <ExternalAnchor href={linkToEvent} title={eventTitle}>
-                          {eventTitle}
-                        </ExternalAnchor>
-                      </Subtitle>
-                      <BodyPrimary noPaddingTop>
-                        {format(date, 'MMMM DD[,] dddd')}
-                      </BodyPrimary>
-                      <Hr />
-                    </li>
-                  )
-                )}
+                {upcomingEvents.map(({ id, eventTitle, date, linkToEvent }) => (
+                  <li key={id}>
+                    <Subtitle noPaddingBottom>
+                      <ExternalAnchor href={linkToEvent} title={eventTitle}>
+                        {eventTitle}
+                      </ExternalAnchor>
+                    </Subtitle>
+                    <BodyPrimary noPaddingTop>
+                      {format(date, 'MMMM DD[,] dddd')}
+                    </BodyPrimary>
+                    <Hr />
+                  </li>
+                ))}
               </ul>
             ) : (
               noEventsMessage(title)

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -258,7 +258,7 @@ class ContactUs extends Component {
           eventsSectionImage,
           eventsSectionDescription
         },
-        allContentfulMeetupEvent: { edges: events },
+        allContentfulMeetupEvent: { nodes: events },
         allContentfulTemplatedCaseStudy,
         allContentfulNonTemplatedCaseStudy
       }
@@ -420,15 +420,12 @@ const Contact = props => (
             }
           }
         }
-
         allContentfulMeetupEvent {
-          edges {
-            node {
-              id
-              eventTitle
-              date
-              linkToEvent
-            }
+          nodes {
+            id
+            eventTitle
+            date
+            linkToEvent
           }
         }
         contentfulOpenSourcePage {

--- a/src/pages/open-source.js
+++ b/src/pages/open-source.js
@@ -52,7 +52,7 @@ const OpenSource = ({ data, location }) => {
       eventsSectionImage,
       eventsSectionDescription
     },
-    allContentfulMeetupEvent: { edges: events }
+    allContentfulMeetupEvent: { nodes: events }
   } = data
 
   const talks = talksSectionTalks.filter(({ type }) => type === 'Talk')
@@ -142,13 +142,11 @@ const OpenSourcePage = props => (
     query={graphql`
       query {
         allContentfulMeetupEvent {
-          edges {
-            node {
-              id
-              eventTitle
-              date
-              linkToEvent
-            }
+          nodes {
+            id
+            eventTitle
+            date
+            linkToEvent
           }
         }
         contentfulOpenSourcePage {

--- a/src/templates/speciality-component.js
+++ b/src/templates/speciality-component.js
@@ -9,11 +9,7 @@ import {
   howWeWorkSchema
 } from './speciality/schemas'
 
-import {
-  getExternalType,
-  getSpecialityEvents,
-  flattenSpeciality
-} from './speciality/methods'
+import { getExternalType, flattenSpeciality } from './speciality/methods'
 
 import IntroSection from '../components/Speciality/Intro'
 import ProjectsSection from '../components/Speciality/Projects'
@@ -34,7 +30,7 @@ export const SpecialityView = props => {
   const {
     data: {
       contentfulSpeciality: speciality,
-      allContentfulMeetupEvent: { edges: events },
+      allContentfulMeetupEvent: { nodes: events },
       videoIcon,
       filteredPosts = []
     }
@@ -61,8 +57,6 @@ export const SpecialityView = props => {
   const talks = getExternalType(flattenedSpeciality, `Talk`)
   const tutorials = getExternalType(flattenedSpeciality, `Tutorial`)
   const books = getExternalType(flattenedSpeciality, `Book`)
-  const specialityEvents =
-    events && events.length > 0 ? getSpecialityEvents(title, events) : []
 
   const renderProjectsSection =
     validateProjects(relatedProjects) || validateClients(clients)
@@ -98,11 +92,7 @@ export const SpecialityView = props => {
       )}
 
       {renderCommunitySection && <CommunitySection {...flattenedSpeciality} />}
-      <EventSection
-        events={specialityEvents}
-        title={title}
-        eventIcon={eventIcon}
-      />
+      <EventSection events={events} title={title} eventIcon={eventIcon} />
 
       {renderTalksSection && (
         <TalksSection talks={talks} videoIcon={videoIcon} />

--- a/src/templates/speciality.js
+++ b/src/templates/speciality.js
@@ -295,14 +295,14 @@ export const pageQuery = graphql`
       contactText
     }
 
-    allContentfulMeetupEvent {
-      edges {
-        node {
-          id
-          eventTitle
-          date
-          linkToEvent
-        }
+    allContentfulMeetupEvent(
+      filter: { specialities: { elemMatch: { id: { in: [$id] } } } }
+    ) {
+      nodes {
+        id
+        eventTitle
+        date
+        linkToEvent
       }
     }
 

--- a/src/templates/speciality/methods.js
+++ b/src/templates/speciality/methods.js
@@ -1,4 +1,3 @@
-import { isAfter, endOfYesterday } from 'date-fns'
 import Get from 'lodash.get'
 import IsNull from 'lodash.isnull'
 
@@ -6,24 +5,6 @@ const getExternalType = (flattenedSpeciality, type) =>
   flattenedSpeciality.externalResources.filter(
     additionalInfo => additionalInfo.type === type
   ) || []
-
-const isSpecialityEvent = (eventTitle, title) => {
-  const formattedTitle = title
-    .toLowerCase()
-    .replace(/(\.|js)/gi, '')
-    .trim()
-
-  return eventTitle.toLowerCase().includes(formattedTitle)
-}
-
-const getSpecialityEvents = (title, events) =>
-  events
-    .filter(
-      ({ node: { eventTitle, date } }) =>
-        isSpecialityEvent(eventTitle, title) && isAfter(date, endOfYesterday())
-    )
-    .sort((a, b) => (a.date <= b.date ? -1 : 1))
-    .slice(0, 5)
 
 const flattenSpeciality = speciality => {
   return {
@@ -132,4 +113,4 @@ const flattenSpeciality = speciality => {
   }
 }
 
-export { getExternalType, getSpecialityEvents, flattenSpeciality }
+export { getExternalType, flattenSpeciality }

--- a/stories/Specialty.stories.js
+++ b/stories/Specialty.stories.js
@@ -138,7 +138,7 @@ class StorySpecialityWrapper extends Component {
         externalResources
       },
       allContentfulMeetupEvent: {
-        edges: events ? eventsData : []
+        nodes: events ? eventsData : []
       }
     }
   }

--- a/stories/assets/speciality-data.js
+++ b/stories/assets/speciality-data.js
@@ -837,20 +837,16 @@ const talkData = [
 
 const eventsData = [
   {
-    node: {
-      id: '5de0f519-22b7-5237-977a-8a27c192ccdf',
-      eventTitle: 'This is a FAKE Node event',
-      date: '2030-01-15T09:30',
-      linkToEvent: 'https://fakelink.com'
-    }
+    id: '5de0f519-22b7-5237-977a-8a27c192ccdf',
+    eventTitle: 'This is a FAKE Node event',
+    date: '2030-01-15T09:30',
+    linkToEvent: 'https://fakelink.com'
   },
   {
-    node: {
-      id: '5de0f519-22b7-5237-977a-8a27c192ccdf',
-      eventTitle: 'This is a second fake Node event',
-      date: '2030-09-15T09:30',
-      linkToEvent: 'https://fakelink.com'
-    }
+    id: '5de0f519-22b7-5237-977a-8a27c192ccdf',
+    eventTitle: 'This is a second fake Node event',
+    date: '2030-09-15T09:30',
+    linkToEvent: 'https://fakelink.com'
   }
 ]
 


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/VMl05xqA/654)

Changes meetup events to query by speciality ID rather than working out if event name contains speciality.

A new field has been added to the meetup event content type, this specialities field enables us to attach specialities to this event which we then query for when rendering each speciality.

K8s Connect event: 
https://app.contentful.com/spaces/22g1lenhck4z/entries/4YAaFl6VtbTfq19b5VYjgn
Has references to [Kubernetes](https://deploy-preview-373--yldio.netlify.com/speciality/kubernetes/) and [DevOps Culture](https://deploy-preview-373--yldio.netlify.com/speciality/devops-culture/) which display the k8s connect event

