### PR TITLE
FIX - remove bad queries from case study and ourwork

### DIFF
--- a/src/pages/case-study/central-working-changing-how-you-work.js
+++ b/src/pages/case-study/central-working-changing-how-you-work.js
@@ -355,11 +355,6 @@ export const query = graphql`
           url
         }
       }
-      ogImageMeta {
-        file {
-          url
-        }
-      }
       genericBlock1 {
         ...GenericFragment
       }

--- a/src/pages/case-study/learnerbly-accelerating-professional-growth.js
+++ b/src/pages/case-study/learnerbly-accelerating-professional-growth.js
@@ -306,11 +306,7 @@ export const query = graphql`
           url
         }
       }
-      ogImageMeta {
-        file {
-          url
-        }
-      }
+
       genericBlock1 {
         ...GenericFragment
       }

--- a/src/pages/our-work.js
+++ b/src/pages/our-work.js
@@ -172,8 +172,6 @@ const OurWorkPage = props => (
               slug
               title
               id
-              seoTitle
-              seoMetaDescription
               services {
                 ... on ContentfulService {
                   title
@@ -200,8 +198,6 @@ const OurWorkPage = props => (
               slug
               title
               id
-              seoTitle
-              seoMetaDescription
               services {
                 ... on ContentfulService {
                   title
@@ -229,8 +225,6 @@ const OurWorkPage = props => (
               slug
               title
               id
-              seoTitle
-              seoMetaDescription
               services {
                 ... on ContentfulService {
                   title


### PR DESCRIPTION
I removed from fields from contentful in some case study templates which meant that the queries are failing on netlify. This SEO meta data fields have already been replaced recently with the SEO Meta Data content type

https://app.netlify.com/sites/yldio/deploys/5d79d1090ddb02a95b857ed6

This PR removes them