### PR TITLE
685  fix broken github lambda

### DIFF
--- a/src/functions/github.js
+++ b/src/functions/github.js
@@ -43,7 +43,7 @@ exports.handler = async evt =>
     const space = await client.getSpace(CONTENTFUL_SPACE)
     const environment = await space.getEnvironment('master')
 
-    const [meta, updatedRepos] = await Promise.all([
+    const [meta, { updatedRepos, missingRepos }] = await Promise.all([
       Meta(environment, {
         openSourceMetaPullRequestsCount,
         openSourceMetaReposCount
@@ -60,7 +60,8 @@ exports.handler = async evt =>
         updatedRepos:
           updatedRepos && updatedRepos.length
             ? updatedRepos
-            : 'No repos updated'
+            : 'No repos updated',
+        missingRepos
       })
     }
   })

--- a/src/functions/oss/utils.js
+++ b/src/functions/oss/utils.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
-const { get } = require('lodash')
+const Get = require('lodash.get')
 
 const { LOCALE = 'en-US' } = process.env
 
-const getFieldValue = (obj, key) => get(obj, `fields.${key}.${LOCALE}`)
+const getFieldValue = (obj, key) => Get(obj, `fields.${key}.${LOCALE}`)
 
 const generateContentfulData = (obj, keys) => {
   if (!keys && !keys.length) {

--- a/tests/unit/lambdas/repos.test.js
+++ b/tests/unit/lambdas/repos.test.js
@@ -110,7 +110,32 @@ describe('Github lambda - Repos util', () => {
       differentRepoOne.nameWithOwner
     )
 
-    const expected = [differentRepoOne.nameWithOwner]
+    const expected = { updatedRepos: [differentRepoOne.nameWithOwner] }
+    expect(response).toStrictEqual(expected)
+  })
+
+  it('should call updateEntry once and return an array of missing repos if there are differences and github data does not contain a matching contentful repo', async () => {
+    const response = await ReposUtil(mockedEnvironment, {
+      repos: [differentRepoOne]
+    })
+
+    const expectedContentfulRepoFromGithub = {
+      ...contentfulRepoOne.fields,
+      pullRequestCount: { 'en-US': 6 }
+    }
+
+    expect(ossUtils.updateEntry).toHaveBeenCalledWith(
+      contentfulRepoOne,
+      expectedContentfulRepoFromGithub,
+      mockedEnvironment,
+      differentRepoOne.nameWithOwner
+    )
+    expect(ossUtils.updateEntry).toHaveBeenCalledTimes(1)
+
+    const expected = {
+      updatedRepos: [differentRepoOne.nameWithOwner],
+      missingRepos: [contentfulRepoTwo.fields.url['en-US']]
+    }
     expect(response).toStrictEqual(expected)
   })
 })


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/b/pqR4eqrX/yldio-design-engineering)

- Update repo.js util to handle missing github data
- Update github.js lambda to report `missingRepos`
- Update tests for github.js and repo.js

The github lambda didn't handle missing github data so is breaking on prod. This is because we expected there to always be github data to match the contentful data, however when someone leaves the yld github org we start seeing missing data...

