### PR TITLE
migrate non-template case study sites to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:storyshots:update": "yarn run test:storyshots -u",
     "test:interaction": "jest --config jest-interaction.config.js",
     "test:interaction:update": "yarn run test:interaction -u",
-    "test:e2e": "testcafe chrome:headless ./tests/e2e/**/*.js -S -s artifacts/screenshots --reporter html:artifacts/screenshots/report.html --assertion-timeout 10000 --selector-timeout 500000",
+    "test:e2e": "testcafe chrome:headless ./tests/e2e/**/*.js -S -s artifacts/screenshots --reporter html:artifacts/screenshots/report.html --assertion-timeout 10000 --selector-timeout 90000",
     "test:lighthouse": "jest --config jest-lighthouse.config.js",
     "test:unit": "jest --config jest-unit.config.js",
     "test:unit:watch": "yarn run test:unit --watch",

--- a/src/pages/case-study/canon-giving-stories-a-new-form.js
+++ b/src/pages/case-study/canon-giving-stories-a-new-form.js
@@ -93,7 +93,7 @@ const GradientContent = ({ text, image }) => (
 )
 
 const IndexPage = ({
-  data: { contentfulNonTemplatedCaseStudy: caseStudy, travel },
+  data: { contentfulNonTemplatedCaseStudyV2: caseStudy, travel },
   location
 }) => {
   return (
@@ -106,7 +106,9 @@ const IndexPage = ({
       <Grid>
         <Row>
           <FirstParagraphCol width={[1, 1, 1, 1, 1 / 2]}>
-            {makeText(caseStudy.genericText1.genericText1).map((p, i) => (
+            {makeText(
+              caseStudy.genericBlock1[0].genericBlockText.genericBlockText
+            ).map((p, i) => (
               <BodyPrimary key={i}>{p}</BodyPrimary>
             ))}
           </FirstParagraphCol>
@@ -134,7 +136,9 @@ const IndexPage = ({
             <Row>
               <RightAlignedCol width={[1, 1, 1, 1 / 2]}>
                 <Margin top={3}>
-                  {makeText(caseStudy.genericText2.genericText2).map((p, i) => (
+                  {makeText(
+                    caseStudy.genericBlock2[0].genericBlockText.genericBlockText
+                  ).map((p, i) => (
                     <BodyPrimary key={i}>{p}</BodyPrimary>
                   ))}
                 </Margin>
@@ -146,7 +150,9 @@ const IndexPage = ({
         <NoMobile tablet as={Grid}>
           <GradientBackground>
             <GradientContent
-              text={caseStudy.genericText3.genericText3}
+              text={
+                caseStudy.genericBlock3[0].genericBlockText.genericBlockText
+              }
               image={travel.childImageSharp}
             />
           </GradientBackground>
@@ -157,7 +163,9 @@ const IndexPage = ({
         <GradientBackground>
           <Grid>
             <GradientContent
-              text={caseStudy.genericText3.genericText3}
+              text={
+                caseStudy.genericBlock3[0].genericBlockText.genericBlockText
+              }
               image={travel.childImageSharp}
             />
           </Grid>
@@ -174,7 +182,9 @@ const IndexPage = ({
               <SectionTitle>Exploring the story</SectionTitle>
             </Col>
             <Col width={[1, 1, 1, 1 / 2]}>
-              {makeText(caseStudy.genericText4.genericText4).map((p, i) => (
+              {makeText(
+                caseStudy.genericBlock4[0].genericBlockText.genericBlockText
+              ).map((p, i) => (
                 <BodyPrimary key={i}>{p}</BodyPrimary>
               ))}
             </Col>
@@ -204,7 +214,9 @@ const IndexPage = ({
                 <SectionTitle>Out in the wild</SectionTitle>
               </Col>
               <Col width={[1, 1, 1, 1 / 2]}>
-                {makeText(caseStudy.genericText5.genericText5).map((p, i) => (
+                {makeText(
+                  caseStudy.genericBlock5[0].genericBlockText.genericBlockText
+                ).map((p, i) => (
                   <BodyPrimary key={i}>{p}</BodyPrimary>
                 ))}
               </Col>
@@ -230,10 +242,10 @@ export const query = graphql`
         }
       }
     }
-    contentfulNonTemplatedCaseStudy(
+    contentfulNonTemplatedCaseStudyV2(
       slug: { eq: "canon-giving-stories-a-new-form" }
     ) {
-      ...NonTemplatedCaseStudyRelated
+      ...NonTemplatedCaseStudyV2Related
       slug
       title
       seoMetaData {
@@ -248,25 +260,20 @@ export const query = graphql`
           url
         }
       }
-      genericText1 {
-        id
-        genericText1
+      genericBlock1 {
+        ...GenericFragment
       }
-      genericText2 {
-        id
-        genericText2
+      genericBlock2 {
+        ...GenericFragment
       }
-      genericText3 {
-        id
-        genericText3
+      genericBlock3 {
+        ...GenericFragment
       }
-      genericText4 {
-        id
-        genericText4
+      genericBlock4 {
+        ...GenericFragment
       }
-      genericText5 {
-        id
-        genericText5
+      genericBlock5 {
+        ...GenericFragment
       }
       specialities {
         title

--- a/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
+++ b/src/pages/case-study/joyent-bringing-application-awareness-to-cloud.js
@@ -77,7 +77,7 @@ const Divider = styled.div`
 
 const IndexPage = ({
   data: {
-    contentfulNonTemplatedCaseStudy: caseStudy,
+    contentfulNonTemplatedCaseStudyV2: caseStudy,
     deployment,
     picture,
     form,
@@ -100,10 +100,14 @@ const IndexPage = ({
             <SectionTitle>The challenge</SectionTitle>
           </Col>
           <Col width={[1, 1, 1, 1, 1 / 2]}>
-            {makeText(caseStudy.genericText1.genericText1).map((p, i) => (
+            {makeText(
+              caseStudy.genericBlock1[0].genericBlockText.genericBlockText
+            ).map((p, i) => (
               <BodyPrimary key={i}>{p}</BodyPrimary>
             ))}
-            {makeText(caseStudy.genericText2.genericText2).map((p, i) => (
+            {makeText(
+              caseStudy.genericBlock2[0].genericBlockText.genericBlockText
+            ).map((p, i) => (
               <BodyPrimary key={i}>{p}</BodyPrimary>
             ))}
           </Col>
@@ -125,7 +129,9 @@ const IndexPage = ({
                   <SectionTitle>Single sign-on</SectionTitle>
                 </SpreadUntilDesktop>
                 <SpreadUntilDesktop>
-                  {makeText(caseStudy.genericText3.genericText3).map((p, i) => (
+                  {makeText(
+                    caseStudy.genericBlock3[0].genericBlockText.genericBlockText
+                  ).map((p, i) => (
                     <BodyPrimary key={i}>{p}</BodyPrimary>
                   ))}
                 </SpreadUntilDesktop>
@@ -151,7 +157,9 @@ const IndexPage = ({
               <SectionTitle>Navigation</SectionTitle>
             </Col>
             <Col width={[1, 1, 1, 1, 1 / 2]}>
-              {makeText(caseStudy.genericText4.genericText4).map((p, i) => (
+              {makeText(
+                caseStudy.genericBlock4[0].genericBlockText.genericBlockText
+              ).map((p, i) => (
                 <BodyPrimary key={i}>{p}</BodyPrimary>
               ))}
             </Col>
@@ -176,7 +184,9 @@ const IndexPage = ({
                 <SectionTitle>App deployment</SectionTitle>
               </SpreadUntilDesktop>
               <SpreadUntilDesktop>
-                {makeText(caseStudy.genericText5.genericText5).map((p, i) => (
+                {makeText(
+                  caseStudy.genericBlock5[0].genericBlockText.genericBlockText
+                ).map((p, i) => (
                   <BodyPrimary key={i}>{p}</BodyPrimary>
                 ))}
               </SpreadUntilDesktop>
@@ -203,7 +213,9 @@ const IndexPage = ({
             <Row>
               <Col width={[1, 1, 1, 1, 5 / 12]}>
                 <SectionTitle>Topology</SectionTitle>
-                {makeText(caseStudy.genericText6.genericText6).map((p, i) => (
+                {makeText(
+                  caseStudy.genericBlock6[0].genericBlockText.genericBlockText
+                ).map((p, i) => (
                   <BodyPrimary key={i}>{p}</BodyPrimary>
                 ))}
               </Col>
@@ -226,7 +238,9 @@ const IndexPage = ({
               <SectionTitle>The big picture</SectionTitle>
             </Col>
             <Col width={[1, 1, 1, 1, 1 / 2]}>
-              {makeText(caseStudy.genericText7.genericText7).map((p, i) => (
+              {makeText(
+                caseStudy.genericBlock7[0].genericBlockText.genericBlockText
+              ).map((p, i) => (
                 <BodyPrimary key={i}>{p}</BodyPrimary>
               ))}
             </Col>
@@ -251,7 +265,9 @@ const IndexPage = ({
                 <SectionTitle>Metrics visualisation</SectionTitle>
               </Col>
               <ColWithoutExtraPadding width={[1, 1, 1, 1, 1 / 2]}>
-                {makeText(caseStudy.genericText8.genericText8).map((p, i) => (
+                {makeText(
+                  caseStudy.genericBlock8[0].genericBlockText.genericBlockText
+                ).map((p, i) => (
                   <BodyPrimary key={i}>{p}</BodyPrimary>
                 ))}
               </ColWithoutExtraPadding>
@@ -280,7 +296,9 @@ const IndexPage = ({
                 <SectionTitle>Monitoring and alerting</SectionTitle>
               </SpreadUntilDesktop>
               <SpreadUntilDesktop>
-                {makeText(caseStudy.genericText9.genericText9).map((p, i) => (
+                {makeText(
+                  caseStudy.genericBlock9[0].genericBlockText.genericBlockText
+                ).map((p, i) => (
                   <BodyPrimary key={i}>{p}</BodyPrimary>
                 ))}
               </SpreadUntilDesktop>
@@ -396,7 +414,7 @@ export const query = graphql`
         }
       }
     }
-    contentfulNonTemplatedCaseStudy(
+    contentfulNonTemplatedCaseStudyV2(
       slug: { eq: "joyent-bringing-application-awareness-to-cloud" }
     ) {
       slug
@@ -413,42 +431,33 @@ export const query = graphql`
           url
         }
       }
-      ...NonTemplatedCaseStudyRelated
-      genericText1 {
-        id
-        genericText1
+      ...NonTemplatedCaseStudyV2Related
+      genericBlock1 {
+        ...GenericFragment
       }
-      genericText2 {
-        id
-        genericText2
+      genericBlock2 {
+        ...GenericFragment
       }
-      genericText3 {
-        id
-        genericText3
+      genericBlock3 {
+        ...GenericFragment
       }
-      genericText4 {
-        id
-        genericText4
+      genericBlock4 {
+        ...GenericFragment
       }
-      genericText5 {
-        id
-        genericText5
+      genericBlock5 {
+        ...GenericFragment
       }
-      genericText6 {
-        id
-        genericText6
+      genericBlock6 {
+        ...GenericFragment
       }
-      genericText7 {
-        id
-        genericText7
+      genericBlock7 {
+        ...GenericFragment
       }
-      genericText8 {
-        id
-        genericText8
+      genericBlock8 {
+        ...GenericFragment
       }
-      genericText9 {
-        id
-        genericText9
+      genericBlock9 {
+        ...GenericFragment
       }
       specialities {
         title

--- a/tests/e2e/training-page-test.js
+++ b/tests/e2e/training-page-test.js
@@ -76,9 +76,11 @@ test('when using the Escape key to close a modal, any future modal that is opene
 
 test("navigating directly to a training course's url should show the same content as navigating via the training page", async t => {
   await t.click(firstModalLink)
-  const titleFromTrainingPageLink = await Selector(
-    '[data-testid="modal-title"]'
-  ).textContent
+  const title = await Selector('[data-testid="modal-title"]')
+
+  await t.expect(title.exists).ok({ timeout: 5000 })
+
+  const titleFromTrainingPageLink = title.textContent
   const location = await getWindowLocation()
 
   await t.navigateTo('/')


### PR DESCRIPTION
## migrate non-template case study sites to v2 - [Trello ticket](https://trello.com/c/SuzY6JtD/690-remove-unnecessary-content-types-so-we-can-have-more-available-ones)

After this, I think we can set the v2 ones to public, delete the old ones and then remove the NonTemplatedCaseStudy queries for `our-work`
