### PR TITLE
HOTFIX - Change Link component to 'a' in footer contact us

### DIFF
--- a/src/components/Common/GetInTouch.js
+++ b/src/components/Common/GetInTouch.js
@@ -147,7 +147,7 @@ const Profile = props => {
                 {person.footerRole}
               </Subtitle>
               <BodyPrimary
-                as={Link}
+                as={'a'}
                 style={{
                   textDecoration: 'underline'
                 }}

--- a/stories/__snapshots__/getInTouch.stories.snapshot
+++ b/stories/__snapshots__/getInTouch.stories.snapshot
@@ -1187,12 +1187,8 @@ exports[`Storyshots GetInTouch GetInTouch - Profile 1`] = `
             Talent Manager
           </h3>
           <a
-            aria-current="page"
             className="c12"
-            href="/"
-            noPadding={true}
-            onClick={[Function]}
-            onMouseEnter={[Function]}
+            href="mailto:nick@yld.io"
             style={
               Object {
                 "textDecoration": "underline",


### PR DESCRIPTION
Enables correct `mailto:` linking 