### PR TITLE
Fix icon spacing in services pages

### DIFF
--- a/src/components/Service/WorkStage.js
+++ b/src/components/Service/WorkStage.js
@@ -36,11 +36,7 @@ const WorkStage = ({ workStage }) => {
     <Row spaced={false}>
       <Col width={[1]}>
         <Padding
-          top={{
-            smallPhone: 0,
-            smallTablet: 5,
-            tablet: 3.5,
-          }}
+          top={{ smallPhone: 0, smallTablet: 5, tablet: 3.5, desktop: 4 }}
           bottom={{ smallPhone: 3, desktop: 4 }}
         >
           <SectionTitle reverse>{workStage.title}</SectionTitle>
@@ -65,7 +61,9 @@ const WorkStage = ({ workStage }) => {
             <ReactMarkdown
               source={body}
               renderers={{
-                paragraph: props => <BodyPrimary muted reverse {...props} />,
+                paragraph: props => (
+                  <BodyPrimary muted reverse noPaddingTop {...props} />
+                ),
                 listItem: props => (
                   <CustomisedBulletpoint muted reverse {...props} />
                 ),

--- a/src/components/Training/Formats.js
+++ b/src/components/Training/Formats.js
@@ -35,7 +35,7 @@ const ImageWrapper = styled.div`
   width: 60px;
   height: 60px;
   max-width: 100%;
-  margin-bottom: ${({ theme }) => theme.space[2]};
+  padding-bottom: ${({ theme }) => theme.space[2]};
 `;
 
 const BulletPointWrapper = styled.div`
@@ -67,7 +67,7 @@ const Formats = ({ formats }) => (
             <Subtitle noPadding reverse>
               {format.title}
             </Subtitle>
-            <BodyPrimary muted reverse>
+            <BodyPrimary muted reverse noPaddingTop>
               {format.description}
             </BodyPrimary>
             <BulletPointWrapper>

--- a/src/components/Typography/BodyPrimaryStyles.js
+++ b/src/components/Typography/BodyPrimaryStyles.js
@@ -4,11 +4,11 @@ import remcalc from 'remcalc';
 import modifiers from './modifiers';
 
 const BodyPrimaryStyles = css`
-  color: ${props => props.theme.colors.text};
+  color: ${({ theme }) => theme.colors.text};
   font-weight: 400;
   font-size: ${remcalc(17)};
   line-height: ${remcalc(24)};
-  padding: ${remcalc(12)} 0;
+  padding: ${({ theme }) => `${theme.space[2]} 0`};
   ${modifiers}
 `;
 


### PR DESCRIPTION
## Description - [Trello ticket](https://trello.com/c/uePerJyQ/708-services-ensure-there-is-the-correct-spacing-between-iconography-and-text-and-between-the-bold-titles-and-body-copy)

Fix the icon spacing inconsistency across the services pages

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [x] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
