### PR TITLE
Generate speciality URL with service slug instead of 'speciality'

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -36,6 +36,13 @@ exports.createPages = async ({ graphql, actions }) => {
           node {
             id
             slug
+            speciality {
+              id
+              slug
+              title
+              generate
+              blogpostTags
+            }
           }
         }
       }
@@ -130,27 +137,6 @@ exports.createPages = async ({ graphql, actions }) => {
     }
   });
 
-  _.each(result.data.allContentfulSpeciality.edges, ({ node }) => {
-    const { id, slug, title, generate, blogpostTags } = node;
-
-    if (slug && generate) {
-      const titleTags = getTagsForTitle(title);
-      const contentfulTags = blogpostTags
-        ? blogpostTags.map(el => el.toLowerCase().trim())
-        : [];
-
-      createPage({
-        path: `/speciality/${slug}/`,
-        component: slash(specialityTemplate),
-        context: {
-          id: id,
-          postsLimit: 3,
-          postsTags: [...titleTags, ...contentfulTags],
-        },
-      });
-    }
-  });
-
   _.each(result.data.allContentfulService.edges, edge => {
     if (edge.node.slug) {
       createPage({
@@ -159,6 +145,27 @@ exports.createPages = async ({ graphql, actions }) => {
         context: {
           id: edge.node.id,
         },
+      });
+
+      _.each(edge.node.speciality, speciality => {
+        const { id, slug, title, generate, blogpostTags } = speciality;
+
+        if (slug && generate) {
+          const titleTags = getTagsForTitle(title);
+          const contentfulTags = blogpostTags
+            ? blogpostTags.map(el => el.toLowerCase().trim())
+            : [];
+
+          createPage({
+            path: `/${edge.node.slug}/${slug}/`,
+            component: slash(specialityTemplate),
+            context: {
+              id: id,
+              postsLimit: 3,
+              postsTags: [...titleTags, ...contentfulTags],
+            },
+          });
+        }
       });
     }
   });

--- a/src/components/Common/BaseVideoLink.js
+++ b/src/components/Common/BaseVideoLink.js
@@ -93,22 +93,14 @@ const BaseVideoLink = ({
     themeVariation,
   );
   const InnerWrapper = mode === 'standalone' ? StandaloneWrapper : 'div';
+  const top = { smallPhone: 2, smallTablet: 1.5 };
+  const bottom = { smallPhone: 0, smallTablet: 1.5 };
 
   return (
     <Wrapper width={[1, 1, 1, 1, 6 / 12, 4 / 12]}>
       <ExternalAnchor href={href} color={color} opacity={opacity} {...props}>
         <InnerWrapper
-          themeVariation={themeVariation}
-          top={
-            mode === 'standalone'
-              ? { smallPhone: 2, smallTablet: 1.5 }
-              : undefined
-          }
-          bottom={
-            mode === 'standalone'
-              ? { smallPhone: 0, smallTablet: 1.5 }
-              : undefined
-          }
+          {...(mode === 'standalone' ? { themeVariation, top, bottom } : {})}
         >
           <Margin vertical={{ smallPhone: 1.5, smallTablet: 0 }}>
             <Padding vertical={1} horizontal={mode === 'standalone' ? 2 : 0}>

--- a/src/components/Common/BlogListing.js
+++ b/src/components/Common/BlogListing.js
@@ -36,12 +36,13 @@ const BlogListing = ({ title, description, posts, bgColor }) => {
 BlogListing.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  mediaItems: PropTypes.array.isRequired,
+  mediaItems: PropTypes.array,
   CTALink: PropTypes.string,
 };
 
 BlogListing.defaultProps = {
   CTALink: '/blog/',
+  mediaItems: [],
 };
 
 export default BlogListing;

--- a/src/components/Common/GetInTouch.js
+++ b/src/components/Common/GetInTouch.js
@@ -244,7 +244,6 @@ const GetInTouch = props => {
 
 GetInTouch.propTypes = {
   title: PropTypes.string.isRequired,
-  contactText: PropTypes.string.isRequired,
   ctaText: PropTypes.string.isRequired,
 };
 

--- a/src/components/Homepage/services.js
+++ b/src/components/Homepage/services.js
@@ -76,7 +76,7 @@ const Services = ({ statement, services }) => (
       {services.map(
         service =>
           service.introSentence && (
-            <>
+            <div key={service.slug}>
               <ServiceCol width={[1, 1, 1, 1 / 2, 5 / 12]}>
                 {service.icon && (
                   <ImageWrapper>
@@ -97,7 +97,7 @@ const Services = ({ statement, services }) => (
               </ServiceCol>
               {/* This grid has no offsets so this is what we're left with... */}
               <Col width={[0, 0, 0, 1 / 12]} />
-            </>
+            </div>
           ),
       )}
     </ServiceRow>

--- a/src/components/Service/IntroSection.js
+++ b/src/components/Service/IntroSection.js
@@ -51,9 +51,9 @@ const IntroSection = ({ introSentence, introBlocks }) => (
           <ImageWrapper>
             {icon && <img src={icon.file.url} alt={subtitle} />}
           </ImageWrapper>
-          {subtitle && <Subtitle noPaddingBottom="true">{subtitle}</Subtitle>}
+          {subtitle && <Subtitle noPaddingBottom>{subtitle}</Subtitle>}
           {body && (
-            <BodyPrimary noPaddingTop="true" muted="true">
+            <BodyPrimary noPaddingTop="true" muted>
               {body}
             </BodyPrimary>
           )}


### PR DESCRIPTION
## Reconstruct speciality paths to /:service/:speciality - [687](https://trello.com/c/LCLlQ9VN/687-reconstruct-speciality-paths-to-service-speciality)

Since every speciality fits inside a service (engineering, design, training or open-souce) the URL will have the service in it (`/:service/:speciality`) instead of using the `/speciality/speciality` as before, which caused some SEO issues since `/speciality` isn't a valid page.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [x] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
