### PR TITLE
Don't render footer on training course modals

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -154,8 +154,8 @@ class Layout extends Component {
                 )}
                 <StyledMain>{children}</StyledMain>
                 <Location>
-                  {({ location: { state: { modal } = {} } }) =>
-                    !modal && (
+                  {({ location }) =>
+                    !(location && location.state && location.state.modal) && (
                       <Footer
                         displayFooterOffices={displayFooterOffices}
                         footerContactUsId={footerContactUsId}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -153,11 +153,21 @@ class Layout extends Component {
                   />
                 )}
                 <StyledMain>{children}</StyledMain>
-                <Footer
-                  displayFooterOffices={displayFooterOffices}
-                  footerContactUsId={footerContactUsId}
-                  is404={is404}
-                />
+                <Location>
+                  {({
+                    location: {
+                      state: { modal },
+                    },
+                  }) =>
+                    !modal && (
+                      <Footer
+                        displayFooterOffices={displayFooterOffices}
+                        footerContactUsId={footerContactUsId}
+                        is404={is404}
+                      />
+                    )
+                  }
+                </Location>
                 <GlobalStyle />
                 {!this.state.cookiesAllowed && (
                   <Cookie onClick={this.handleClick} />

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -154,11 +154,7 @@ class Layout extends Component {
                 )}
                 <StyledMain>{children}</StyledMain>
                 <Location>
-                  {({
-                    location: {
-                      state: { modal },
-                    },
-                  }) =>
+                  {({ location: { state: { modal } = {} } }) =>
                     !modal && (
                       <Footer
                         displayFooterOffices={displayFooterOffices}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -136,13 +136,15 @@ class Layout extends Component {
                     : null}
                 </Helmet>
                 <Location>
-                  {({ location }) => (
-                    <Header
-                      slug={slug}
-                      path={location.pathname}
-                      bgColor={bgColor}
-                    />
-                  )}
+                  {({ location }) =>
+                    !(location && location.state && location.state.modal) && (
+                      <Header
+                        slug={slug}
+                        path={location.pathname}
+                        bgColor={bgColor}
+                      />
+                    )
+                  }
                 </Location>
                 {GridDebugger && (
                   <GridDebugger


### PR DESCRIPTION
## H2 headings - ‘Cloaking’ issue - [746](https://trello.com/c/m0AGp9j5/746-h2-headings-cloaking-issue)

> ‘Cloaking’ is where you show the end-user different content than you are showing to crawlers. This is a violation of Google’s Webmaster Guidelines and can result in a search penalty.

Since the footer isn't visible for the users inside a training course page (it's bellow the modal), remove it from the DOM tree.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [x] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
