### PR TITLE
Fix outlines and underlines

### DIFF
--- a/src/components/Common/Tab.js
+++ b/src/components/Common/Tab.js
@@ -38,7 +38,7 @@ const Underline = css`
   transform-origin: left;
   transform: scaleX(0);
 
-  ${is('current')`
+  ${is('active')`
     transform: scaleX(1);
   `};
 `;
@@ -46,10 +46,12 @@ const Underline = css`
 const Button = styled(UnstyledButton)`
   position: relative;
   outline: none;
+  cursor: pointer;
 
   ${breakpoint('desktop')`
     &:active,
     &:focus {
+      cursor: unset;
       &:after {
         transform: scaleX(1);
       }

--- a/src/components/Training/course/CourseInfo.js
+++ b/src/components/Training/course/CourseInfo.js
@@ -41,7 +41,9 @@ const CourseInfo = ({
       body={preRequisitesCourses}
     />
     <Padding top={2}>
-      <StyledLink to="/contact">{courseInfoSectionNames.contactUs}</StyledLink>
+      <StyledLink to="/contact" style={{ position: 'absolute' }}>
+        {courseInfoSectionNames.contactUs}
+      </StyledLink>
     </Padding>
   </Col>
 );


### PR DESCRIPTION
## Boxes around 'leadership 'advisors' and 'client' look strange - [768](https://trello.com/c/L2E1hR9S/768-boxes-around-leadership-advisors-and-client-look-strange)

- Fix the outline around _Contact us_ button on training course modal
- Add an underline to the selected tab upon 1st render on the _About us_ page

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [x] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
