### PR TITLE
Fit 2 logos per row on mobile

### DIFF
--- a/src/components/Common/LogoGrid.js
+++ b/src/components/Common/LogoGrid.js
@@ -22,7 +22,6 @@ const LogoItem = styled(Col)`
     :nth-child(even) {
       padding-right: ${props => props.theme.space[2]};
     }
-
     :nth-child(odd) {
       padding-left: ${props => props.theme.space[2]};
     }
@@ -44,6 +43,11 @@ const LogoItem = styled(Col)`
   `}
 `;
 
+const CustomAnchor = styled(ExternalAnchor)`
+  width: 100%;
+  max-width: 250px;
+`;
+
 const LogoGrid = ({ companies }) => (
   <StyledRow>
     {companies.map(company => (
@@ -52,13 +56,12 @@ const LogoGrid = ({ companies }) => (
         key={company.id}
       >
         {company.url ? (
-          <ExternalAnchor href={company.url} title={company.title}>
+          <CustomAnchor href={company.url} title={company.title}>
             <Image
               image={company.image}
-              width="250px"
               style={{ filter: 'grayscale(1)', saturate: '0' }}
             />
-          </ExternalAnchor>
+          </CustomAnchor>
         ) : (
           <Image
             image={company}


### PR DESCRIPTION
## Crowding of logos - [773](https://trello.com/c/b0JbdtQN/773-crowding-of-logos)

Reduce logos size on mobile so it can fit 2 items per row.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [x] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
