### PR TITLE
fix: use same selection rules on body for headers

### DIFF
--- a/src/components/Blog/post/Typography.js
+++ b/src/components/Blog/post/Typography.js
@@ -16,6 +16,11 @@ const H1 = styled.h1`
     font-size: ${remcalc(42)};
     line-height: ${remcalc(51)};
   `}
+
+  *::selection,
+  ::selection {
+    background-color: ${({ theme }) => theme.colors.vibrant};
+  }
 `;
 
 const H2 = styled.h2`
@@ -30,6 +35,11 @@ const H2 = styled.h2`
     font-size: ${remcalc(28)};
     line-height: ${remcalc(42)};
   `}
+
+  *::selection,
+  ::selection {
+    background-color: ${({ theme }) => theme.colors.vibrant};
+  }
 `;
 
 const Subtitle = styled.h3`
@@ -44,6 +54,11 @@ const Subtitle = styled.h3`
     font-size: ${remcalc(24)};
     line-height: ${remcalc(36)};
   `}
+
+  *::selection,
+  ::selection {
+    background-color: ${({ theme }) => theme.colors.vibrant};
+  }
 `;
 
 const Body = styled.p`


### PR DESCRIPTION
## Description 
Issue reported on [slack](https://yld.slack.com/archives/C176N3FD4/p1603288344000900).

We should have the same `::selection` CSS rules on every typography element.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
