### PR TITLE
chore: capitalize join us header

### DIFF
--- a/src/components/Header/utils/navLinks.js
+++ b/src/components/Header/utils/navLinks.js
@@ -50,7 +50,7 @@ const navLinks = [
         to: '/about-us/',
       },
       {
-        label: 'Join us',
+        label: 'Join Us',
         to: '/join-us/',
       },
     ],

--- a/src/pages/join-us.js
+++ b/src/pages/join-us.js
@@ -38,7 +38,7 @@ class JoinUs extends React.Component {
 
     const breadcrumbData = generateBreadcrumbData(siteUrl, [
       {
-        name: 'Join us',
+        name: 'Join Us',
         pathname: location.pathname,
         position: 2,
       },


### PR DESCRIPTION
## Description

Hannah requested to standardize the About header section. We have `Join us` and `About Us`.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
