### PR TITLE
Remove underline on hover of left headers

### DIFF
--- a/src/components/Header/DesktopNav/StyledHeaderLink.js
+++ b/src/components/Header/DesktopNav/StyledHeaderLink.js
@@ -13,7 +13,6 @@ const StyledHeaderLink = styled(InternalAnchor)`
   `}
 
   &:hover {
-    text-decoration: underline;
     color: ${props => props.color};
   }
 `;


### PR DESCRIPTION
## Description - [Trello ticket](link)

Luis requested that the underline should be removed from the words at the top left of the page when you hover.

## Checklist

- [ ] Updating or creating a new page? Consider any SEO requirements such as:
  - [ ] Does the page have an `h1` tag?
  - [ ] Does the page have a correctly formed meta title?
  - [ ] Does the page have a correctly formed meta description?
  - [ ] Does the page have a unique `og:image` tag (if required)?
- [ ] checked that this PR resolves the spec provided from trello / this description

If you're unsure how to check these SEO requirements please reach out to your colleagues for help!
