### PR TITLE
Divide join-us categories by team rather than location

### DIFF
--- a/src/components/Common/JobLink.js
+++ b/src/components/Common/JobLink.js
@@ -11,7 +11,7 @@ const JobLink = ({ position, hostedUrl, contractType, location }) => (
   >
     <BodyPrimary noPaddingBottom>{position}</BodyPrimary>
     <BodyPrimary noPaddingTop muted>
-      {contractType}
+      {location} - {contractType}
     </BodyPrimary>
     <Hr short />
   </ExternalAnchor>

--- a/src/components/Common/JobsByLocation.js
+++ b/src/components/Common/JobsByLocation.js
@@ -4,13 +4,14 @@ import { StaticQuery, graphql } from 'gatsby';
 const JOBS_BY_LOCATION = graphql`
   query JOBS_BY_CITY {
     allLever(limit: 40) {
-      group(field: categories___location) {
+      group(field: categories___team) {
         edges {
           node {
             id
             categories {
               location
               commitment
+              team
             }
             text
             hostedUrl
@@ -21,32 +22,26 @@ const JOBS_BY_LOCATION = graphql`
   }
 `;
 
+const sortJobs = (jobsByCategory, limit) => {
+  const sortedJobs = [];
+  jobsByCategory.forEach((group) => {
+    const { team } = group.edges[0].node.categories;
+    const limitedJobs = group.edges.slice(0, limit);
+
+    sortedJobs.push({
+      team,
+      jobs: limitedJobs,
+    });
+  });
+
+  return sortedJobs;
+};
+
 /**
  * Aux function for adjusting the group ordering.
  * The current sorting brought from the query is alphabetical but
  * it seems London is suppposed to come first in the list.
  */
-const sortJobs = (jobsByLocation, limit) => {
-  const sortedJobs = [];
-  jobsByLocation.forEach((group) => {
-    const { location } = group.edges[0].node.categories;
-    const limitedJobs = group.edges.slice(0, limit);
-
-    if (location === 'London') {
-      sortedJobs.unshift({
-        location,
-        jobs: limitedJobs,
-      });
-    } else {
-      sortedJobs.push({
-        location,
-        jobs: limitedJobs,
-      });
-    }
-  });
-
-  return sortedJobs;
-};
 
 const JobsByLocation = ({ children, sort = sortJobs, limit }) => (
   <StaticQuery

--- a/src/components/Common/OpenPositions.js
+++ b/src/components/Common/OpenPositions.js
@@ -30,20 +30,20 @@ const OpenPositions = ({ data: { title }, limit = 4 }) => (
       <SectionTitle>{title}</SectionTitle>
       <JobsByLocation limit={limit}>
         {(jobs) =>
-          jobs.map(({ location, jobs }, idx) => (
+          jobs.map(({ team, jobs }, idx) => (
             <Padding key={idx} top={3}>
-              <Subtitle>{location}</Subtitle>
+              <Subtitle>{team}</Subtitle>
               <Padding top={2}>
                 <Row as="ul">
                   {jobs.map((job, idx) => {
                     const {
                       text,
                       hostedUrl,
-                      categories: { commitment },
+                      categories: { commitment, location },
                     } = job.node;
                     return (
                       <Col
-                        key={`job-${location}-${idx}`}
+                        key={`job-${text}-${idx}`}
                         as="li"
                         width={[1, 1, 1, 1, 4 / 12, 3 / 12]}
                       >


### PR DESCRIPTION
## Description

Reworked components in order to group all the jobs in terms of their team rather than their location. Each job has a `category`, which in turn has a `team`, like we see in this [example](https://api.lever.co/v0/postings/yld?mode=json).